### PR TITLE
Added default values for nutrient recovery in WOFOST. Fixes issue #22

### DIFF
--- a/ukwofost/crop_manager.py
+++ b/ukwofost/crop_manager.py
@@ -78,7 +78,12 @@ class Crop:
     in the soil when the crop is not yet in the ground.
     """
 
-    DEFAULT_ARGS = {"TimedEvents": "Null"}
+    DEFAULT_ARGS = {
+        "TimedEvents": "Null",
+        "N_recovery": 0.7,
+        "P_recovery": 0.7,
+        "K_recovery": 0.7,
+    }
 
     def __init__(self, calendar_year, crop, **kwargs):
         self.crop = crop
@@ -134,6 +139,9 @@ class Crop:
                 "line_template": (
                     "- {timing}: {{N_amount: {event[N_amount]}, "
                     "P_amount: {event[P_amount]}, K_amount: {event[K_amount]}}}"
+                    "P_amount: {event[P_amount]}, K_amount: {event[K_amount]}, "
+                    "N_recovery: {args[N_recovery]}, P_recovery: {args[P_recovery]}, "
+                    "K_recovery: {args[K_recovery]}}}"
                 ),
             },
             "mowing": {
@@ -156,7 +164,7 @@ class Crop:
                         self.variety, args["crop_start_date"], event
                     )
                     line = event_data["line_template"].format(
-                        timing=timing, event=event
+                        timing=timing, event=event, args=args
                     )
                     event_lines.append(line)
                 events_table = "\n                    ".join(event_lines)


### PR DESCRIPTION
Fixes #22

Nutrient recovery values for each nutrient class have been added. These are set as defaults as a class variables in the `Crop` class. They can be overridden passing `N_recovery`, `P_recovery` and `K_recovery` key-value pairs (dictionaries) to the optional `**kwargs` when generating an instance of the class `Crop`. 