### PR TITLE
Fixed sorting issue of input file defining rotations to run WOFOST in bulk

### DIFF
--- a/bulk_wofost_simulator.py
+++ b/bulk_wofost_simulator.py
@@ -73,9 +73,7 @@ def run_rotations(input_sample_df, output_filename):
         for rotation in lonlat_df["rotation"].unique():
             rotation_df = lonlat_df[lonlat_df["rotation"] == rotation]
             for item in rotation_df["iteration"].unique():
-                item_df = rotation_df[rotation_df["iteration"] == item].sort_values(
-                    by="year"
-                )
+                item_df = rotation_df[rotation_df["iteration"] == item]
 
                 print(
                     f"Running simulator for '{rotation}' and iteration "


### PR DESCRIPTION
Removed sorting by year of rotations contained in input file ro run WOFOST in bulk in *bulk_wofost_simulator.py*