### PR TITLE
Removed mistakenly repeted lines in template event type in Crop._generate_agromanagement()

### DIFF
--- a/ukwofost/crop_manager.py
+++ b/ukwofost/crop_manager.py
@@ -139,7 +139,6 @@ class Crop:
                 "line_template": (
                     "- {timing}: {{N_amount: {event[N_amount]}, "
                     "P_amount: {event[P_amount]}, K_amount: {event[K_amount]},"
-                    "P_amount: {event[P_amount]}, K_amount: {event[K_amount]}, "
                     "N_recovery: {args[N_recovery]}, P_recovery: {args[P_recovery]}, "
                     "K_recovery: {args[K_recovery]}}}"
                 ),


### PR DESCRIPTION
The template *event_types* for fertilisation events in Crop._generate_agromanagement() had P and K amounts duplicated, which resulted in WOFOST incorrectly picking fertilisation quantities applied to the crop.