### PR TITLE
Updated WofostSimulator.run() to return either the full Wofost output or the summary yields at harvest

### DIFF
--- a/run_wofost.py
+++ b/run_wofost.py
@@ -26,32 +26,34 @@ of the Crop class is instantiated (line 45). More information on
 agromanagment can be found at https://tinyurl.com/bdcmj5b7
 """
 
-from ukwofost.core.crop_manager import Crop, CropRotation
+from ukwofost.core.crop_manager import Crop
 from ukwofost.core.defaults import defaults
 from ukwofost.core.simulation_manager import WofostSimulator
 from ukwofost.core.utils import lonlat2osgrid
 
 # Define input parameters
-LON, LAT = -3.4111140552800747, 57.13317708272391
-CROPS = ["wheat", "fallow", "potato"]
-YEARS = [2020, 2021, 2022]
-
+LON, LAT = -1.670330465465696, 55.028574354445425
+CROP = "wheat"
+YEAR = 2019
 # Build Wofost simulator
 os_code = lonlat2osgrid((LON, LAT), 10)
 sim = WofostSimulator(
-    parcel=os_code, weather_provider="Chess", soil_provider="SoilGrids"
+    location=os_code, weather_provider="ERA5", soil_provider="SoilGrids"
 )
 
-# Define management
-rotation = []
-for item in zip(CROPS, YEARS):
-    crop = item[0]
-    year = item[1]
-    crop_params = defaults.get("management").get(crop)
-    rotation.append(Crop(calendar_year=year, crop=crop, **crop_params))
+crop_management = defaults.get("management").get(CROP)
+crop = Crop(calendar_year=YEAR, crop=CROP, **crop_management)
+crop_output = sim.run(crop_or_rotation=crop, output_flag="full")
+# # Define management
+# rotation = []
+# for item in zip(CROPS, YEARS):
+#     crop = item[0]
+#     year = item[1]
+#     crop_params = defaults.get("management").get(crop)
+#     rotation.append(Crop(calendar_year=year, crop=crop, **crop_params))
 
-crop_rotation = CropRotation(rotation)
+# crop_rotation = CropRotation(rotation)
 
 # Run WOFOST to compute crop yield
-crop_yield = sim.run(crop_rotation)
-print(crop_yield)
+# crop_yield = sim.run(crop_rotation)
+# print(crop_yield)

--- a/ukwofost/core/simulation_manager.py
+++ b/ukwofost/core/simulation_manager.py
@@ -11,6 +11,7 @@ space
 
 import pandas as pd
 from pcse.base import ParameterProvider
+
 # from pcse.models import Wofost80_NWLP_FD_beta
 # from pcse.models import Wofost72_WLP_FD, LINGRA_WLP_FD
 from pcse.db.nasapower import NASAPowerWeatherDataProvider
@@ -21,9 +22,11 @@ from ukwofost.core.defaults import defaults, wofost_parameters
 from ukwofost.core.parcel import Parcel
 from ukwofost.core.utils import lonlat2osgrid, osgrid2lonlat
 from ukwofost.data_providers.soil_manager import SoilGridsDataProvider
-from ukwofost.data_providers.weather_manager import (Era5WeatherDataProvider,
-                                                     NetCDFWeatherDataProvider,
-                                                     ParcelWeatherDataProvider)
+from ukwofost.data_providers.weather_manager import (
+    Era5WeatherDataProvider,
+    NetCDFWeatherDataProvider,
+    ParcelWeatherDataProvider,
+)
 
 
 # pylint: disable=R0902

--- a/ukwofost/core/simulation_manager.py
+++ b/ukwofost/core/simulation_manager.py
@@ -11,7 +11,6 @@ space
 
 import pandas as pd
 from pcse.base import ParameterProvider
-
 # from pcse.models import Wofost80_NWLP_FD_beta
 # from pcse.models import Wofost72_WLP_FD, LINGRA_WLP_FD
 from pcse.db.nasapower import NASAPowerWeatherDataProvider
@@ -22,11 +21,9 @@ from ukwofost.core.defaults import defaults, wofost_parameters
 from ukwofost.core.parcel import Parcel
 from ukwofost.core.utils import lonlat2osgrid, osgrid2lonlat
 from ukwofost.data_providers.soil_manager import SoilGridsDataProvider
-from ukwofost.data_providers.weather_manager import (
-    Era5WeatherDataProvider,
-    NetCDFWeatherDataProvider,
-    ParcelWeatherDataProvider,
-)
+from ukwofost.data_providers.weather_manager import (Era5WeatherDataProvider,
+                                                     NetCDFWeatherDataProvider,
+                                                     ParcelWeatherDataProvider)
 
 
 # pylint: disable=R0902
@@ -243,20 +240,24 @@ class WofostSimulator:
             )
         return soildata
 
-    def run(self, crop_or_rotation, **kwargs):
+    def run(self, crop_or_rotation, output_flag, **kwargs):
         """
         Method to run Wofost for the crop specified in 'crop' and
         with default crop parameters unless custom parameters are
         specified in **kwargs
         :param crop_or_rotation: an instance of the class 'Crop'
-               (see crop_manager.py for more info)
+            (see crop_manager.py for more info)
+        :param output_flag (str): can be declared as "summary" or
+            "full" and flags whether the ouptut of the wofost run is
+            a time series of all ouput variables returned by Wofost, or
+            the summary yield value at harvest
         :param **kwargs: optional dictionary with key-value pairs
-               for any of the parameters that need to be customised:
-               these only include the underlying WOFOST parameters
-               (see wofost_params class attribute), but not agromanagement
-               parameters. Non-default agromanagement parameters must be
-               modified when initialising the instance of the class 'Crop'
-               which is then passed to this method
+            for any of the parameters that need to be customised:
+            these only include the underlying WOFOST parameters
+            (see wofost_params class attribute), but not agromanagement
+            parameters. Non-default agromanagement parameters must be
+            modified when initialising the instance of the class 'Crop'
+            which is then passed to this method
         """
         if isinstance(crop_or_rotation, Crop):
             self.cropd.set_active_crop(
@@ -286,8 +287,20 @@ class WofostSimulator:
             wofsim = Wofost80_NWLP_FD_beta(parameters, self.wdp, crop_rotation)
             wofsim.run_till_terminate()
             # Collect output
-            summary_output = wofsim.get_summary_output()
-            return summary_output[0]["TWSO"]
+            if output_flag == "summary":
+                summary_output = wofsim.get_summary_output()
+                return summary_output[0]["TWSO"]
+            if output_flag == "full":
+                output = wofsim.get_output()
+                df = pd.DataFrame(output)
+                df.set_index("day", inplace=True, drop=True)
+                return df
+            raise ValueError(
+                'The "output_flag" input argument can only '
+                'take values of "full" for a time series of all'
+                ' output variables or "summary" for the yield at'
+                " harvest!"
+            )
             # pylint: enable=R0914
 
         if isinstance(crop_or_rotation, CropRotation):
@@ -317,11 +330,20 @@ class WofostSimulator:
                     f" due to {e}"
                 )
             # pylint: enable=W0718
-            output = wofsim.get_output()
-
-            df = pd.DataFrame(output)
-            df.set_index("day", inplace=True, drop=True)
-            return df
+            if output_flag == "summary":
+                summary_output = wofsim.get_summary_output()
+                return summary_output[0]["TWSO"]
+            if output_flag == "full":
+                output = wofsim.get_output()
+                df = pd.DataFrame(output)
+                df.set_index("day", inplace=True, drop=True)
+                return df
+            raise ValueError(
+                'The "output_flag" input argument can only '
+                'take values of "full" for a time series of all'
+                ' output variables or "summary" for the yield at'
+                " harvest!"
+            )
         raise ValueError(f"Unsupported type: {type(crop_or_rotation)}")
 
     def _override_defaults(self, default_parameters, item):


### PR DESCRIPTION
Updated WofostSimulator.run() method to return either the full time series of all output variables returned by Wofost or the summary yield at harvest based on a user flag argument