### PR TITLE
Iss_54_add_parameter_builder

### DIFF
--- a/ukwofost/core/crop_manager.py
+++ b/ukwofost/core/crop_manager.py
@@ -91,7 +91,8 @@ class Crop:
         self.crop = crop
         self.crop_type = self._categorize_crop()
         self.calendar_year = calendar_year
-        self.agromanagement = self._generate_agromanagement(**kwargs)
+        self._agromanagement = self._generate_agromanagement(**kwargs)
+        self.agromanagement = yaml.safe_load(self._agromanagement)
 
     # pylint: disable=R0914, R0912
     def _generate_agromanagement(self, **kwargs):
@@ -273,7 +274,7 @@ class Crop:
             msg += "Variety: " + self.variety + "\n"
         msg += "Crop type: " + self.crop_type + "\n"
         msg += "-------------------Agro-management--------------------\n"
-        msg += self.agromanagement
+        msg += self._agromanagement
 
         return msg
 
@@ -291,15 +292,15 @@ class CropRotation:
     """
 
     def __init__(self, crops):
-        self.rotation = yaml.safe_load(self._generate_rotation(crops))
-        self.crop_list = self._list_crops()
         self.yaml_rotation = self._generate_rotation(crops)
+        self.rotation = yaml.safe_load(self.yaml_rotation)
+        self.crop_list = self._list_crops()
 
     def _generate_rotation(self, crops):
-        rotation_yaml = ""
+        rotation_yaml = []
         for crop in crops:
-            rotation_yaml += crop.agromanagement + "\n"
-        return rotation_yaml
+            rotation_yaml += crop.agromanagement
+        return yaml.dump(rotation_yaml)
 
     def _list_crops(self):
         crops = self.find_value("crop_name")

--- a/ukwofost/core/defaults.py
+++ b/ukwofost/core/defaults.py
@@ -191,6 +191,22 @@ wofost_parameters = set(
     ]
 )
 
+soil_parameters = set(
+    [
+        "WILTING_POTENTIAL",
+        "FIELD_CAPACITY",
+        "CRAIRC",
+        "SOPE",
+        "KSUB",
+        "RDMSOL",
+        "SPADS",
+        "SPODS",
+        "SPASS",
+        "SPOSS",
+        "DEFLIM",
+    ]
+)
+
 moisture_adjustment = {
     "wheat": 0.145,
     "barley": 0.145,

--- a/ukwofost/core/simulation_manager.py
+++ b/ukwofost/core/simulation_manager.py
@@ -18,7 +18,7 @@ from pcse.db.nasapower import NASAPowerWeatherDataProvider
 from pcse.models import LINGRA_WLP_FD, Wofost80_NWLP_FD_beta
 
 from ukwofost.core.crop_manager import Crop, CropRotation
-from ukwofost.core.defaults import defaults, wofost_parameters
+from ukwofost.core.defaults import defaults, soil_parameters, wofost_parameters
 from ukwofost.core.parcel import Parcel
 from ukwofost.core.utils import lonlat2osgrid, osgrid2lonlat
 from ukwofost.data_providers.soil_manager import SoilGridsDataProvider
@@ -29,7 +29,7 @@ from ukwofost.data_providers.weather_manager import (
 )
 
 
-# pylint: disable=R0902
+# pylint: disable=R0902,R0914
 class WofostSimulator:
     """
     Class generating a Wofost simulator that allows to
@@ -262,6 +262,18 @@ class WofostSimulator:
             modified when initialising the instance of the class 'Crop'
             which is then passed to this method
         """
+        # Override soil parameters if needed
+        soil_kwargs = {}
+        non_soil_kwargs = {}
+        for key, value in kwargs.items():
+            if key in soil_parameters:
+                soil_kwargs[key] = value
+            else:
+                non_soil_kwargs[key] = value
+
+        if soil_kwargs:
+            self.soildata.update_soil_data(**soil_kwargs)
+
         if isinstance(crop_or_rotation, Crop):
             self.cropd.set_active_crop(
                 crop_or_rotation.crop, crop_or_rotation.variety
@@ -274,7 +286,8 @@ class WofostSimulator:
                 sitedata=self.sitedata,
             )
 
-            self._override_defaults(parameters, kwargs)
+            # override all non-soil parameters if needed
+            self._override_defaults(parameters, non_soil_kwargs)
 
             # generate agromanagement
             crop_rotation = CropRotation([crop_or_rotation]).rotation
@@ -304,7 +317,6 @@ class WofostSimulator:
                 ' output variables or "summary" for the yield at'
                 " harvest!"
             )
-            # pylint: enable=R0914
 
         if isinstance(crop_or_rotation, CropRotation):
             agromanagement = crop_or_rotation.rotation
@@ -379,4 +391,4 @@ class WofostSimulator:
         return msg
 
 
-# pylint: enable=R0902
+# pylint: enable=R0902,R0914

--- a/ukwofost/data_providers/soil_manager.py
+++ b/ukwofost/data_providers/soil_manager.py
@@ -40,10 +40,10 @@ class SoilDataProvider(dict):
     # class attributes
     _DATA_SOURCE = None
     _DEFAULT_SOILVARS = ["sand", "silt", "clay"]
-    _WILTING_POTENTIAL = log10(1.5e4)
-    _FIELD_CAPACITY = log10(150)
 
     _defaults = {
+        "WILTING_POTENTIAL": log10(1.5e4),
+        "FIELD_CAPACITY": log10(150),
         "CRAIRC": 0.060,
         "SOPE": 1.47,
         "KSUB": 1.47,
@@ -81,8 +81,8 @@ class SoilDataProvider(dict):
         smtab = [x for pair in zip(psi, water_ret) for x in pair]
         # Permanent wilting point conventianally at 1500 kPa, fc
         # between 10-30kPa
-        wp_idx = psi.index(nearest(self._WILTING_POTENTIAL, psi))
-        fc_idx = psi.index(nearest(self._FIELD_CAPACITY, psi))
+        wp_idx = psi.index(nearest(self._defaults["WILTING_POTENTIAL"], psi))
+        fc_idx = psi.index(nearest(self._defaults["FIELD_CAPACITY"], psi))
         smw = water_ret[wp_idx]
         smfcf = water_ret[fc_idx]
         sm0 = water_ret[0]
@@ -151,15 +151,18 @@ class SoilGridsDataProvider(SoilDataProvider):
 
     def __init__(self, osgrid_code):
         super().__init__()
-        soil_texture_list = self._load_soil_data(osgrid_code)
-        self.update(self._return_soildata(osgrid_code, soil_texture_list))
+        self._osgrid_code = osgrid_code
+        self._soil_texture_list = self._load_soil_data()
+        self.update(
+            self._return_soildata(self._osgrid_code, self._soil_texture_list)
+        )
 
-    def _load_soil_data(self, osgrid_code):
+    def _load_soil_data(self):
         """
         Retrieve soil data from xarray file based on location defined in
         osgrid_code
         """
-        lon, lat = osgrid2lonlat(osgrid_code, epsg=4326)
+        lon, lat = osgrid2lonlat(self._osgrid_code, epsg=4326)
         soil_array = xr.open_dataset(SoilGridsDataProvider._SOIL_PATH)
 
         soil_df = (
@@ -192,6 +195,19 @@ class SoilGridsDataProvider(SoilDataProvider):
         # in this order. Last 3 optional
         soil_df = soil_df.iloc[0].tolist()
         return soil_df
+
+    def update_soil_data(self, **kwargs):
+        """
+        Update the soil data dictionary with the new values provided
+        """
+        for key, value in kwargs.items():
+            if key in self._defaults:
+                self._defaults[key] = value
+            else:
+                raise KeyError(f"{key} not in defaults")
+        self.update(
+            self._return_soildata(self._osgrid_code, self._soil_texture_list)
+        )
 
 
 # class WHSDDataProvider(SoilDataProvider):


### PR DESCRIPTION
This PR addresses Issue #54. For simplicity, we kept the same structure as before, but added the possibility to alter soil parameters and rebuild water retention and water condictivity curves. This was initially initialised when instantiating the `WofostSimulator`; Now, the `run()` method associated to the `WofostSimulator` can take a number of `**kwargs`, to both override default crop parameters as well as soil parameters. When new soil parameters are defined, the underlying model computing water retention and conductivity is re-run and the output is updated. This happens within the `SoilGridsDataProvider.update_soil_data()` method.  
Default soil parameters that can be overridden are declared in `defaults.py`.  

While this works and is reasonably fast, as it does not require to reload the entirety of the soil data and instead keeps the granulometric fractions retrieved from data at initialisation, the way in which parameters are overridden in general (not only soil parameters) is a bit clunky. In particular, agromanagement parameters can be overridden when instantiating crops or rotations, and crop and wofost parameters can be overridden (through different methods) within the `run()` method of the WofostSimulator. There are surely better ways of doing this.

