### PR TITLE
Check WOFOST responsiveness to changes in soil parameters

### DIFF
--- a/bulk_wofost_simulator.py
+++ b/bulk_wofost_simulator.py
@@ -29,8 +29,11 @@ import math
 import pandas as pd
 
 from ukwofost.core.crop_manager import Crop, CropBuilder, CropRotation
-from ukwofost.core.defaults import (moisture_adjustment, soil_parameters,
-                                    wofost_parameters)
+from ukwofost.core.defaults import (
+    moisture_adjustment,
+    soil_parameters,
+    wofost_parameters,
+)
 from ukwofost.core.simulation_manager import WofostSimulator
 from ukwofost.core.utils import find_contiguous_sets, lonlat2osgrid
 
@@ -69,7 +72,7 @@ def run_rotations(input_sample_df, output_filename):
         os_code = lonlat2osgrid((lon, lat), 10)
         sim = WofostSimulator(
             location=os_code,
-            weather_provider="Chess",
+            weather_provider="ERA5",
             soil_provider="SoilGrids",
         )
         lonlat_df = input_sample_df[

--- a/ukwofost/core/simulation_manager.py
+++ b/ukwofost/core/simulation_manager.py
@@ -67,7 +67,7 @@ class WofostSimulator:
     __str__(self, /)
         Return str(self).
 
-    run(self, crop, **kwargs)
+    run(self, crop_or_rotation, output_flag, **kwargs)
         run the Wofost simulator
     """
 
@@ -223,7 +223,7 @@ class WofostSimulator:
             wdp = None
             raise ValueError(
                 "weather provider can only be 'NASA', "
-                "'Chess', 'Downscaled' or 'ERA5"
+                "'Chess', 'Downscaled' or 'ERA5'"
             )
         return wdp
 
@@ -262,7 +262,14 @@ class WofostSimulator:
             parameters must be modified when initialising the instance of
             the class 'Crop' which is then passed to this method
         """
-        # Override soil parameters if needed
+        # Override soil parameters if needed. This bit of hte code is clunky
+        # because, while soil parameters can be overwritten through the
+        # set_override() method in the ParameterProvider class, changing
+        # most soil parameters requires re-running the Van-Genuchten
+        # equations to update the soil hydraulic properties which can't be
+        # easily done through the ParameterProvider class as it is part of
+        # the pcse package.
+
         soil_kwargs = {}
         non_soil_kwargs = {}
         for key, value in kwargs.items():


### PR DESCRIPTION
This PR addresses Issue #59 to test the responsiveness of WOFOTS to changes in input parameters of the soil.  
I could not find any bugs in the code and 
- the model does respond as expected to changes in soil parameters (although I was expecting larger changes in yields when changing matric potentials assigned to wilting point and field capacity);
- the bulk simulator from file and the one-off simulator from script in which input parameters are passed manually return identical yields and output if driven by the same input parameter sets.

