### PR TITLE
Update environment file to specify PCSE version

### DIFF
--- a/wofost-env.yml
+++ b/wofost-env.yml
@@ -22,7 +22,7 @@ dependencies:
   - xarray
   - yaml
   - pip:
-      - pcse==5.5.3
+      - pcse>=5.5,<6.0
       - rosetta-soil
       - soiltexture
 

--- a/wofost-env.yml
+++ b/wofost-env.yml
@@ -22,7 +22,7 @@ dependencies:
   - xarray
   - yaml
   - pip:
-      - pcse
+      - pcse=5.5.3
       - rosetta-soil
       - soiltexture
 

--- a/wofost-env.yml
+++ b/wofost-env.yml
@@ -22,7 +22,7 @@ dependencies:
   - xarray
   - yaml
   - pip:
-      - pcse=5.5.3
+      - pcse==5.5.3
       - rosetta-soil
       - soiltexture
 


### PR DESCRIPTION
As the current PCSE verison (6.0) is not backward compatible with 5.5, which is the one currently used in the code, we need to specify in the Conda environment file to use PCSE 5.5. This addresses Issue #61