### PR TITLE
Removed call to NASA Power to estimate Angstrom coefficients

### DIFF
--- a/ukwofost/core/simulation_manager.py
+++ b/ukwofost/core/simulation_manager.py
@@ -11,7 +11,6 @@ space
 
 import pandas as pd
 from pcse.base import ParameterProvider
-
 # from pcse.models import Wofost80_NWLP_FD_beta
 # from pcse.models import Wofost72_WLP_FD, LINGRA_WLP_FD
 from pcse.db.nasapower import NASAPowerWeatherDataProvider
@@ -22,11 +21,9 @@ from ukwofost.core.defaults import defaults, soil_parameters, wofost_parameters
 from ukwofost.core.parcel import Parcel
 from ukwofost.core.utils import lonlat2osgrid, osgrid2lonlat
 from ukwofost.data_providers.soil_manager import SoilGridsDataProvider
-from ukwofost.data_providers.weather_manager import (
-    Era5WeatherDataProvider,
-    NetCDFWeatherDataProvider,
-    ParcelWeatherDataProvider,
-)
+from ukwofost.data_providers.weather_manager import (Era5WeatherDataProvider,
+                                                     NetCDFWeatherDataProvider,
+                                                     ParcelWeatherDataProvider)
 
 
 # pylint: disable=R0902,R0914

--- a/ukwofost/core/simulation_manager.py
+++ b/ukwofost/core/simulation_manager.py
@@ -11,6 +11,7 @@ space
 
 import pandas as pd
 from pcse.base import ParameterProvider
+
 # from pcse.models import Wofost80_NWLP_FD_beta
 # from pcse.models import Wofost72_WLP_FD, LINGRA_WLP_FD
 from pcse.db.nasapower import NASAPowerWeatherDataProvider
@@ -21,9 +22,11 @@ from ukwofost.core.defaults import defaults, soil_parameters, wofost_parameters
 from ukwofost.core.parcel import Parcel
 from ukwofost.core.utils import lonlat2osgrid, osgrid2lonlat
 from ukwofost.data_providers.soil_manager import SoilGridsDataProvider
-from ukwofost.data_providers.weather_manager import (Era5WeatherDataProvider,
-                                                     NetCDFWeatherDataProvider,
-                                                     ParcelWeatherDataProvider)
+from ukwofost.data_providers.weather_manager import (
+    Era5WeatherDataProvider,
+    NetCDFWeatherDataProvider,
+    ParcelWeatherDataProvider,
+)
 
 
 # pylint: disable=R0902,R0914

--- a/ukwofost/core/utils.py
+++ b/ukwofost/core/utils.py
@@ -918,14 +918,10 @@ def check_angstrom(angst_a, angst_b):
     sum_ab = angstrom_a + angstrom_b
     if angstrom_a < min_a or angstrom_a > max_a:
         msg = "invalid Angstrom A value!"
-        raise ValueError(
-            f"{msg} : this must be between {min_a} and {max_a}."
-        )
+        raise ValueError(f"{msg} : this must be between {min_a} and {max_a}.")
     if angstrom_b < min_b or angstrom_b > max_b:
         msg = "invalid Angstrom B value!"
-        raise ValueError(
-            f"{msg} : this must be between {min_b} and {max_b}."
-        )
+        raise ValueError(f"{msg} : this must be between {min_b} and {max_b}.")
     if sum_ab < min_sum_ab or sum_ab > max_sum_ab:
         msg = "invalid sum of Angstrom A & B values!"
         raise ValueError(
@@ -962,14 +958,16 @@ def estimate_angstrom(toa=None, toc=None):
 
     # check if sufficient data is available to make a reasonable estimate:
     # As a rule of thumb we want to have at least 200 days available
-    if len(toa) < 200 or len (toc) < 200:
-        msg = ("Less then 200 days of data available. Reverting to " +
-                "default Angstrom A/B coefficients (%f, %f)")
+    if len(toa) < 200 or len(toc) < 200:
+        msg = (
+            "Less then 200 days of data available. Reverting to "
+            + "default Angstrom A/B coefficients (%f, %f)"
+        )
         angstrom_a, angstrom_b = angst_a, angst_b
         return angstrom_a, angstrom_b
 
     # calculate relative radiation (swv_dwn/toa_dwn) and percentiles
-    relative_radiation = toc/toa
+    relative_radiation = toc / toa
     ix = relative_radiation.notnull()
     angstrom_a = float(np.percentile(relative_radiation[ix].values, 5))
     angstrom_ab = float(np.percentile(relative_radiation[ix].values, 98))
@@ -978,7 +976,9 @@ def estimate_angstrom(toa=None, toc=None):
     try:
         angstrom_a, angstrom_b = check_angstrom(angstrom_a, angstrom_b)
     except ValueError as e:
-        msg = ("Angstrom A/B values (%f, %f) outside valid range: %s. " +
-                "Reverting to default values.")
+        msg = (
+            "Angstrom A/B values (%f, %f) outside valid range: %s. "
+            + "Reverting to default values."
+        )
         msg = msg % (angstrom_a, angstrom_b, e)
     return angstrom_a, angstrom_b

--- a/ukwofost/core/utils.py
+++ b/ukwofost/core/utils.py
@@ -89,7 +89,7 @@ check_angstrom(angst_a, angst_b):
     Routine checks validity of Angstrom coefficients.
     This has been taken straight from the pcse package
     developed by Wageningen University and contained in
-    pcse.db.NASAPowerWeatherDataProvider    
+    pcse.db.NASAPowerWeatherDataProvider
 
 estimate_angstrom(toa=None, toc=None):
     Determine Angstrom A/B parameters from Top-of-Atmosphere and

--- a/ukwofost/core/utils.py
+++ b/ukwofost/core/utils.py
@@ -85,6 +85,16 @@ read_parcel_data(gid, folder):
     Read UKCEH parcel data retrieved from a series of
     files contained in "folder".
 
+check_angstrom(angst_a, angst_b):
+    Routine checks validity of Angstrom coefficients.
+    This has been taken straight from the pcse package
+    developed by Wageningen University and contained in
+    pcse.db.NASAPowerWeatherDataProvider    
+
+estimate_angstrom(toa=None, toc=None):
+    Determine Angstrom A/B parameters from Top-of-Atmosphere and
+    top-of-Canopy radiation values if present.
+
 """
 
 import json
@@ -98,6 +108,7 @@ from math import exp, floor, log
 from math import radians as rad
 from math import sin, tan
 
+import numpy as np
 import pandas as pd
 import psycopg2
 from pyproj import Transformer
@@ -877,3 +888,97 @@ def read_parcel_data(gid, folder):
                         coords = feature["rp"]
                         metadata[parcel_id] = coords
     return metadata.get(gid, "Parcel not found")
+
+
+def check_angstrom(angst_a, angst_b):
+    """
+    Routine checks validity of Angstrom coefficients.
+    This has been taken straight from the pcse package
+    developed by Wageningen University and contained in
+    pcse.db.NASAPowerWeatherDataProvider
+
+    Parameters
+    ----------
+    :param angst_a (float): Angstrom A coefficient
+    :param angst_b (float): Angstrom B coefficient
+
+    Return
+    ------
+    :return: tuple of Angstrom A and B coefficients
+
+    """
+    min_a = 0.1
+    max_a = 0.4
+    min_b = 0.3
+    max_b = 0.7
+    min_sum_ab = 0.6
+    max_sum_ab = 0.9
+    angstrom_a = abs(angst_a)
+    angstrom_b = abs(angst_b)
+    sum_ab = angstrom_a + angstrom_b
+    if angstrom_a < min_a or angstrom_a > max_a:
+        msg = "invalid Angstrom A value!"
+        raise ValueError(
+            f"{msg} : this must be between {min_a} and {max_a}."
+        )
+    if angstrom_b < min_b or angstrom_b > max_b:
+        msg = "invalid Angstrom B value!"
+        raise ValueError(
+            f"{msg} : this must be between {min_b} and {max_b}."
+        )
+    if sum_ab < min_sum_ab or sum_ab > max_sum_ab:
+        msg = "invalid sum of Angstrom A & B values!"
+        raise ValueError(
+            f"{msg} : this must be between {min_sum_ab} and {max_sum_ab}."
+        )
+    return angstrom_a, angstrom_b
+
+
+def estimate_angstrom(toa=None, toc=None):
+    """
+    Determine Angstrom A/B parameters from Top-of-Atmosphere and
+    top-of-Canopy radiation values if present.
+    The Angstrom A/B parameters are determined by dividing swv_dwn by toa_dwn
+    and taking the 0.05 percentile for Angstrom A and the 0.98 percentile for
+    Angstrom A+B: toa_dwn*(A+B) approaches the upper envelope while
+    toa_dwn*A approaches the lower envelope of the records of swv_dwn
+    values.
+
+    Parameters
+    ----------
+    :param toa: Top of the Atmosphere radiation
+    :param toc: Top of the Canopy radiation
+
+    Return
+    ------
+    :return: tuple of Angstrom A/B values
+    """
+    angst_a = 0.29
+    angst_b = 0.49
+
+    if toa is None or toc is None:
+        angstrom_a, angstrom_b = angst_a, angst_b
+        return angstrom_a, angstrom_b
+
+    # check if sufficient data is available to make a reasonable estimate:
+    # As a rule of thumb we want to have at least 200 days available
+    if len(toa) < 200 or len (toc) < 200:
+        msg = ("Less then 200 days of data available. Reverting to " +
+                "default Angstrom A/B coefficients (%f, %f)")
+        angstrom_a, angstrom_b = angst_a, angst_b
+        return angstrom_a, angstrom_b
+
+    # calculate relative radiation (swv_dwn/toa_dwn) and percentiles
+    relative_radiation = toc/toa
+    ix = relative_radiation.notnull()
+    angstrom_a = float(np.percentile(relative_radiation[ix].values, 5))
+    angstrom_ab = float(np.percentile(relative_radiation[ix].values, 98))
+    angstrom_b = angstrom_ab - angstrom_a
+
+    try:
+        angstrom_a, angstrom_b = check_angstrom(angstrom_a, angstrom_b)
+    except ValueError as e:
+        msg = ("Angstrom A/B values (%f, %f) outside valid range: %s. " +
+                "Reverting to default values.")
+        msg = msg % (angstrom_a, angstrom_b, e)
+    return angstrom_a, angstrom_b

--- a/ukwofost/data_providers/weather_manager.py
+++ b/ukwofost/data_providers/weather_manager.py
@@ -32,6 +32,7 @@ from ukwofost.core.utils import (
     nearest,
     osgrid2lonlat,
     rh_to_vpress,
+    estimate_angstrom,
 )
 
 
@@ -149,11 +150,8 @@ class NetCDFWeatherDataProvider(WeatherDataProvider):
         # pylint: enable=E1101
 
         # Retrieve Angstrom coefficients A and B
-        w = NASAPowerWeatherDataProvider(
-            latitude=self.latitude, longitude=self.longitude
-        )
         # pylint: disable=C0103
-        self.angstA, self.angstB = check_angstromAB(w.angstA, w.angstB)
+        self.angstA, self.angstB = estimate_angstrom()
         # pylint: enable=C0103
 
         # Check for existence of a cache file
@@ -621,11 +619,8 @@ class ParcelWeatherDataProvider(WeatherDataProvider):
 
     def _create_angstrom(self):
         """Find and assign Angstrom coefficients A and B"""
-        w = NASAPowerWeatherDataProvider(
-            latitude=self.latitude, longitude=self.longitude
-        )
         # pylint: disable=C0103
-        self.angstA, self.angstB = check_angstromAB(w.angstA, w.angstB)
+        self.angstA, self.angstB = estimate_angstrom()
 
     def _load_cache_file(self, csv_fname):
         cache_filename = self._find_cache_file(csv_fname)
@@ -939,11 +934,8 @@ class Era5WeatherDataProvider(WeatherDataProvider):
 
     def _create_angstrom(self):
         """Find and assign Angstrom coefficients A and B"""
-        w = NASAPowerWeatherDataProvider(
-            latitude=self.latitude, longitude=self.longitude
-        )
         # pylint: disable=C0103
-        self.angstA, self.angstB = check_angstromAB(w.angstA, w.angstB)
+        self.angstA, self.angstB = estimate_angstrom()
 
     def _load_cache_file(self, csv_fname):
         cache_filename = self._find_cache_file(csv_fname)

--- a/ukwofost/data_providers/weather_manager.py
+++ b/ukwofost/data_providers/weather_manager.py
@@ -16,11 +16,10 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 from pcse.base import WeatherDataContainer, WeatherDataProvider
-from pcse.db import NASAPowerWeatherDataProvider
 from pcse.exceptions import PCSEError
 from pcse.fileinput.csvweatherdataprovider import ParseError, csvdate_to_date
 from pcse.settings import settings
-from pcse.util import check_angstromAB, reference_ET
+from pcse.util import reference_ET
 
 from ukwofost.core import app_config
 from ukwofost.core.parcel import Parcel


### PR DESCRIPTION
This PR partially solves Issue #63.   

Here I created a placeholder procedure to compute the Angstrom A and B coefficients and I removed the call to the 'NASA Power' weather data provider to get the estimates of the coefficients. 
As now no actual estimation is done, the model will use default Angstrom A and B coefficients
