### PR TITLE
Updated defaults.py to include new crops

### DIFF
--- a/ukwofost/core/defaults.py
+++ b/ukwofost/core/defaults.py
@@ -218,6 +218,7 @@ moisture_adjustment = {
     "spring_barley": 0.145,
     "spring_oats": 0.145,
     "spring_wheat": 0.145,
+    "sugarbeet": 0.710,
     "winter_barley": 0.145,
     "winter_oats": 0.145,
     "winter_wheat": 0.145,

--- a/ukwofost/core/defaults.py
+++ b/ukwofost/core/defaults.py
@@ -208,11 +208,17 @@ soil_parameters = set(
 )
 
 moisture_adjustment = {
-    "wheat": 0.145,
-    "barley": 0.145,
-    "rapeseed": 0.12,
-    "potato": 0.79,
-    "rye_grass": 0.75,
-    "maize": 0.155,
+    "fababeans": 0.145,
     "fallow": None,
+    "maize": 0.155,
+    "peas": 0.145,
+    "potato": 0.79,
+    "rapeseed": 0.12,
+    "rye_grass": 0.75,
+    "spring_barley": 0.145,
+    "spring_oats": 0.145,
+    "spring_wheat": 0.145,
+    "winter_barley": 0.145,
+    "winter_oats": 0.145,
+    "winter_wheat": 0.145,
 }


### PR DESCRIPTION
This PR addresses Issue #66 adding a series of new crops to WOFOST. The crops themselves are parametrised with yaml files which are not tracked with git and are contained in an external folder (see `config.ini` configuration file).

The changes here relate to the `defaults.py` file which contains the values of moisture content at harvest for ecah crop.