### PR TITLE
Updated procedures to run Wofost driven by the Mesoclim downscaled weather data

### DIFF
--- a/bulk_parcel_simulator.py
+++ b/bulk_parcel_simulator.py
@@ -1,0 +1,186 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2025 LEEP, University of Exeter (UK)
+# Mattia Mancini (m.c.mancini@exeter.ac.uk), February 2025
+# ========================================================
+"""
+bulk_parcel_simulator.py
+========================
+Run multiple instances of WOFOST based on an input file
+(a .csv file) containing in each row a combination of
+input parameters within the full input parameter space
+allowed by WOFOST. Briefly, there can be categorized into:
+    - 1) Initial soil conditions
+    - 2) agromanagement (crops, varieties, rotations)
+    - 3) location (hence weather and soil)
+    - 4) year (hence also weather)
+While not needed at the moment, this script will allow to
+also override default crop parameters
+Given the structure of the WofostSimulator, we first set
+appropriate initial parameters for each crop using instances
+of the Crop class, and then we build rotations (which are
+going to be identifiable in the .csv file as multiple rows
+which correspond to the same rotation identifier) using
+instances of the CropRotation class
+"""
+
+import argparse
+import math
+
+import pandas as pd
+
+from ukwofost.core.crop_manager import Crop, CropBuilder, CropRotation
+from ukwofost.core.defaults import (
+    moisture_adjustment,
+    soil_parameters,
+    wofost_parameters,
+)
+from ukwofost.core.parcel import Parcel
+from ukwofost.core.simulation_manager import WofostSimulator
+from ukwofost.core.utils import find_contiguous_sets
+
+
+def apply_conversion(df_row):
+    """
+    Function to convert yields in kg DM to kg at standard harvest moisture
+    """
+    try:
+        twso = df_row["TWSO"]
+        crop = df_row["crop"]
+
+        if isinstance(twso, float) and math.isnan(twso):
+            return None
+
+        return twso / (1 - moisture_adjustment.get(crop, 0))
+    except TypeError:
+        return None
+
+
+# pylint: disable=R0914
+def run_rotations(input_sample_df, output_filename):
+    """
+    Function that reads the rows of a csv file containing
+    input parameters for runs of Wofost, builds crop rotations
+    which are then run through Wofost returning a dataframe with
+    all WOFOST output parameters
+    """
+
+    unique_parcels = input_sample_df["parcel_id"].drop_duplicates()
+    crop_yield = pd.DataFrame()
+    # Iterate over unique locations
+    for parcel in unique_parcels:
+        parcel_obj = Parcel(parcel)
+        sim = WofostSimulator(
+            location=parcel_obj,
+            weather_provider="Mesoclim",
+            soil_provider="SoilGrids",
+        )
+        parcel_df = input_sample_df[
+            (input_sample_df["parcel_id"] == parcel)
+        ]
+
+        # Iterate over rotations
+        for rotation in parcel_df["rotation"].unique():
+            rotation_df = parcel_df[parcel_df["rotation"] == rotation]
+            for item in rotation_df["iteration"].unique():
+                try:
+                    item_df = rotation_df[rotation_df["iteration"] == item]
+
+                    print(
+                        f"Running simulator for '{rotation}' and iteration "
+                        f"'{str(item)}' in parcel '{parcel}'"
+                    )
+                    # Deal with parameters overridden by user (e.g., initial
+                    # soil conditions, or Wofost crop parameters)
+                    parameter_dict = item_df.iloc[0, :].to_dict()
+                    nonstandard_parameters = {
+                        key: value
+                        for key, value in parameter_dict.items()
+                        if key in wofost_parameters or key in soil_parameters
+                    }
+
+                    # Build rotation
+                    crops_in_rotation = []
+                    for _, row in item_df.iterrows():
+                        # Agromanagement of crop rotation
+                        crop_args = CropBuilder(row)
+                        crop_params = crop_args.crop_parameters
+                        crop = Crop(
+                            crop_args.calendar_year,
+                            crop_args.crop,
+                            **crop_params,
+                        )
+                        crops_in_rotation.append(crop)
+
+                    crop_rotation = CropRotation(crops_in_rotation)
+                    rotation_output = sim.run(
+                        crop_or_rotation=crop_rotation,
+                        output_flag="full",
+                        **nonstandard_parameters,
+                    ).reset_index(drop=False)
+
+                    rotation_output["parcel_id"] = parcel
+                    rotation_output["rotation"] = rotation
+                    rotation_output["iteration"] = item
+                    crop_list = [
+                        list(d.keys())[0] for d in crop_rotation.crop_list
+                    ]
+                    crop_indices = find_contiguous_sets(rotation_output, "LAI")
+                    crop_column = [
+                        crop_list[index - 1] if index > 0 else "fallow"
+                        for index in crop_indices
+                    ]
+                    rotation_output["crop"] = crop_column
+
+                    # yield conversion
+                    rotation_output["yield"] = rotation_output.apply(
+                        apply_conversion, axis=1
+                    )
+
+                    crop_yield = pd.concat(
+                        [crop_yield, rotation_output], ignore_index=True
+                    )
+
+                    print("Done...")
+                # pylint: disable=W0621, W0718
+                except Exception as e:
+                    print(e)
+                    continue
+                # pylint: enable=W0621, W0718
+
+    crop_yield.to_csv(output_filename, index=False)
+    print("All jobs completed\n------------------")
+
+
+# pylint: disable=R0914
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Run the Wofost Crop yield simulator"
+    )
+    parser.add_argument(
+        "-i",
+        "--input",
+        type=str,
+        required=True,
+        help="Path to the input CSV file",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=str,
+        required=True,
+        help=("Path of the folder where the output CSV files" "will be saved"),
+    )
+
+    args = parser.parse_args()
+    input_file = args.input
+    output_file = args.output
+    try:
+        input_df = pd.read_csv(input_file)
+        run_rotations(input_df, output_file)
+    except FileNotFoundError:
+        print(f"File not found: {input_file}")
+    # pylint: disable=W0718
+    except Exception as e:
+        print(f"An error occurred: {e}")
+    # pylint: disable=W0718

--- a/ukwofost/core/simulation_manager.py
+++ b/ukwofost/core/simulation_manager.py
@@ -46,7 +46,7 @@ class WofostSimulator:
         - an instance of the Parcel class (Parcel);
         - a lon-lat pair into a tuple (tuple)
     :param weather_provider (Str): either "Chess" (i.e., UKCEH
-        ChessScape UKCP18 1km), "Downscaled" (i.e., weather data
+        ChessScape UKCP18 1km), "Mesoclim" (i.e., weather data
         produced through data fusion and in csv format), "NASA"
         (i.e., the default WOFOST NASA historic weather data provider)
         or "ERA5" (i.e., historic Copernicus ERA5 reanalysis data in
@@ -210,7 +210,7 @@ class WofostSimulator:
             wdp = NetCDFWeatherDataProvider(
                 self.osgrid_code, self._rcp, self._ensemble
             )
-        elif self.weather_provider == "Downscaled":
+        elif self.weather_provider == "Mesoclim":
             if isinstance(self._parcel, str):
                 raise TypeError(
                     "Custom weather data can only be retrieved for parcels "
@@ -223,7 +223,7 @@ class WofostSimulator:
             wdp = None
             raise ValueError(
                 "weather provider can only be 'NASA', "
-                "'Chess', 'Downscaled' or 'ERA5'"
+                "'Chess', 'Mesoclim' or 'ERA5'"
             )
         return wdp
 

--- a/ukwofost/data_providers/weather_manager.py
+++ b/ukwofost/data_providers/weather_manager.py
@@ -455,11 +455,11 @@ class ParcelWeatherDataProvider(WeatherDataProvider):
     }
 
     variable_mapping = {
-        "date": "DAY",
-        "tasmin": "TMIN",
-        "tasmax": "TMAX",
-        "pr": "RAIN",
-        "wspeed": "WIND",
+        "Date": "DAY",
+        "tmin": "TMIN",
+        "tmax": "TMAX",
+        "prec": "RAIN",
+        "windspeed": "WIND",
     }
 
     # pylint: disable=R0913,C0103
@@ -467,7 +467,7 @@ class ParcelWeatherDataProvider(WeatherDataProvider):
         self,
         parcel,
         delimiter=",",
-        dateformat="%Y-%m-%d",
+        dateformat="%d/%m/%Y",
         ETmodel="PM",
         force_reload=False,
     ):
@@ -540,13 +540,12 @@ class ParcelWeatherDataProvider(WeatherDataProvider):
         """
         obs = csv.DictReader(csv_file, delimiter=delimiter, quotechar='"')
         keys_to_remove = [
-            "tasmean",
-            "trange",
-            "swdown",
-            "lwdown",
-            "hurs",
-            "huss",
-            "psfc",
+            "swrad",
+            "lwrad",
+            "cloud",
+            "relhum",
+            "pres",
+            "winddir",
         ]
 
         renamed_obs = []
@@ -557,9 +556,9 @@ class ParcelWeatherDataProvider(WeatherDataProvider):
 
             renamed_d["SNOWDEPTH"] = np.nan
             renamed_d["VAP"] = rh_to_vpress(
-                float(d["hurs"]), float(d["tasmean"])
+                float(d["relhum"]), float(renamed_d["TMIN"])
             )
-            renamed_d["IRRAD"] = float(d["swdown"])
+            renamed_d["IRRAD"] = float(d["swrad"])
 
             # Merge with the remaining data
             renamed_d.update(d)


### PR DESCRIPTION
This PR addresses Issue #65. Here I updated the procedures to run Wofost using the downscaled weather data produced using the Mesoclim R package. Changes involved dealing with weather variable names and date formats correctly, as well as the move from lon-lat based quesrying of data to querying based on parcel IDs. These are the ones contained in CEH LCMs. 