### PR TITLE
Updated workflow to pass Unix-based commands which could fix the issue with deployment on the server not actually happening while still returning a successful status check

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -63,10 +63,10 @@ jobs:
           SERVER_HOST: ${{ secrets.SERVER_HOST }}
         shell: powershell
         run: |
-          ssh -i $HOME\.ssh\id_rsa_github_CD $env:SERVER_USER@$env:SERVER_HOST `
-          "cd /Users/Shared/UkWofost && `
-          git pull origin dev && `
-          source /Users/Shared/miniconda3/etc/profile.d/conda.sh && `
-          conda env update -f /Users/Shared/UkWofost/wofost-env.yml --name wofost || `
-          conda activate /Users/Shared/miniconda3/envs/wofost && `
-          echo 'Model updated successfully!'"
+          ssh -i $HOME\.ssh\id_rsa_github_CD $env:SERVER_USER@$env:SERVER_HOST << 'EOF'
+          cd /Users/Shared/UkWofost
+          git pull origin dev
+          source /Users/Shared/miniconda3/etc/profile.d/conda.sh
+          conda env update -f /Users/Shared/UkWofost/wofost-env.yml --name wofost
+          echo 'Model updated successfully!'
+          EOF

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -63,10 +63,9 @@ jobs:
           SERVER_HOST: ${{ secrets.SERVER_HOST }}
         shell: powershell
         run: |
-          ssh -i $HOME\.ssh\id_rsa_github_CD $env:SERVER_USER@$env:SERVER_HOST << 'EOF'
-          cd /Users/Shared/UkWofost
-          git pull origin dev
-          source /Users/Shared/miniconda3/etc/profile.d/conda.sh
-          conda env update -f /Users/Shared/UkWofost/wofost-env.yml --name wofost
-          echo 'Model updated successfully!'
-          EOF
+          ssh -i $HOME\.ssh\id_rsa_github_CD $env:SERVER_USER@$env:SERVER_HOST `
+          "cd /Users/Shared/UkWofost && \
+          git pull origin dev && \
+          source /Users/Shared/miniconda3/etc/profile.d/conda.sh && \
+          conda env update -f /Users/Shared/UkWofost/wofost-env.yml --name wofost && \
+          echo 'Model updated successfully!'"


### PR DESCRIPTION
This PR attempts to fix an issue with successful deployment status checks but unsuccessful deployment of code changes on the server. I assume this was due to the commands passed through ssh being Powershell based rather than Unix-based. This wouold give me a bunch of `zsh:5: command not found: ^M`.

