### PR TITLE
Updated path definition to be OS independent

### DIFF
--- a/ukwofost/core/__init__.py
+++ b/ukwofost/core/__init__.py
@@ -6,10 +6,11 @@
 UkWofost package initialisation file
 """
 
+import os
 from ukwofost.core.config_parser import ConfigReader
 from ukwofost.utility.paths import ROOT_DIR
 
-config_path = ROOT_DIR + "\\config.ini"
+config_path = os.path.join(ROOT_DIR, "config.ini")
 # pylint: disable=E1101
 app_config = ConfigReader(config_path)
 # pylint: enable=E1101


### PR DESCRIPTION
This PR hopefully addresses Issue #81 by making paths OS independent using the Python os package instead of string concatenation. 