### PR TITLE
Fixed issue with parsing dates generated on different OSs

### DIFF
--- a/run_wofost.py
+++ b/run_wofost.py
@@ -28,17 +28,20 @@ agromanagment can be found at https://tinyurl.com/bdcmj5b7
 
 from ukwofost.core.crop_manager import Crop
 from ukwofost.core.defaults import defaults
+from ukwofost.core.parcel import Parcel
 from ukwofost.core.simulation_manager import WofostSimulator
 from ukwofost.core.utils import lonlat2osgrid
 
 # Define input parameters
 LON, LAT = -1.670330465465696, 55.028574354445425
-CROP = "wheat"
+CROP = "winter_wheat"
 YEAR = 2019
+PARCEL_ID = 578422
+parcel = Parcel(PARCEL_ID)
 # Build Wofost simulator
-os_code = lonlat2osgrid((LON, LAT), 10)
+# os_code = lonlat2osgrid((LON, LAT), 10)
 sim = WofostSimulator(
-    location=os_code, weather_provider="ERA5", soil_provider="SoilGrids"
+    location=parcel, weather_provider="Mesoclim", soil_provider="SoilGrids"
 )
 
 crop_management = defaults.get("management").get(CROP)

--- a/ukwofost/core/__init__.py
+++ b/ukwofost/core/__init__.py
@@ -7,6 +7,7 @@ UkWofost package initialisation file
 """
 
 import os
+
 from ukwofost.core.config_parser import ConfigReader
 from ukwofost.utility.paths import ROOT_DIR
 

--- a/ukwofost/data_providers/weather_manager.py
+++ b/ukwofost/data_providers/weather_manager.py
@@ -25,13 +25,13 @@ from ukwofost.core import app_config
 from ukwofost.core.parcel import Parcel
 from ukwofost.core.utils import (
     calc_doy,
+    estimate_angstrom,
     find_closest_point,
     get_dtm_values,
     lonlat2osgrid,
     nearest,
     osgrid2lonlat,
     rh_to_vpress,
-    estimate_angstrom,
 )
 
 
@@ -468,7 +468,7 @@ class ParcelWeatherDataProvider(WeatherDataProvider):
         parcel,
         delimiter=",",
         dateformat="%d/%m/%Y",
-        possible_date_formats = None,
+        possible_date_formats=None,
         ETmodel="PM",
         force_reload=False,
     ):
@@ -578,7 +578,9 @@ class ParcelWeatherDataProvider(WeatherDataProvider):
                     except ValueError:
                         continue
                 else:
-                    raise ValueError(f"Date {d['DAY']} is not in a recognized format")
+                    raise ValueError(
+                        f"Date {d['DAY']} is not in a recognized format"
+                    )
                 row = {"DAY": day}
                 for label, func in self.obs_conversions.items():
                     value = float(d[label])

--- a/ukwofost/data_providers/weather_manager.py
+++ b/ukwofost/data_providers/weather_manager.py
@@ -468,6 +468,7 @@ class ParcelWeatherDataProvider(WeatherDataProvider):
         parcel,
         delimiter=",",
         dateformat="%d/%m/%Y",
+        possible_date_formats = None,
         ETmodel="PM",
         force_reload=False,
     ):
@@ -477,6 +478,8 @@ class ParcelWeatherDataProvider(WeatherDataProvider):
         self.parcel_id = parcel.parcel_id
         self.elevation = parcel.elevation
         self.dateformat = dateformat
+        if possible_date_formats is None:
+            possible_date_formats = ["%d/%m/%Y", "%Y-%m-%d"]
         self.ETmodel = ETmodel
         self.nodata_value = -99
         self.has_sunshine = False
@@ -568,8 +571,14 @@ class ParcelWeatherDataProvider(WeatherDataProvider):
 
         for i, d in enumerate(renamed_obs):
             try:
-                day = None
-                day = csvdate_to_date(d["DAY"], self.dateformat)
+                for fmt in self.possible_date_formats:
+                    try:
+                        day = csvdate_to_date(d["DAY"], fmt)
+                        break
+                    except ValueError:
+                        continue
+                else:
+                    raise ValueError(f"Date {d['DAY']} is not in a recognized format")
                 row = {"DAY": day}
                 for label, func in self.obs_conversions.items():
                     value = float(d[label])


### PR DESCRIPTION
This PR addresses Issue #83.
When running Wofost driven by csv weather files generated using the downscaling procedures in Mesoclim, depending on whether the downscaling has happened in Windows or MacOS, the csv file will have a different format for the dates. What might look as "24/02/2011" on Windows, might be "2011-02-24" on MacOS. What's stranger is that a file that looks to have dates in the "24/02/2011" format when opened in Excel, might end up having the other format if the csv file was created on MacOS, which means depending on the OS used to create the weather files, the readed in the Weather Data Provider in Python will work or fail. 
I fixed the issue creating a loop through different available date formats. This is not great as 1) it might not be comprehensive; 2) it might still break for example if the format specified is `"%Y-%m-%d"` but the actual format is "%Y-%d-%M".
However, this was a quick fix and seems to be working enough for now.

