### PR TITLE
Deactivated logging procedures

### DIFF
--- a/bulk_parcel_simulator.py
+++ b/bulk_parcel_simulator.py
@@ -24,6 +24,7 @@ instances of the CropRotation class
 """
 
 import argparse
+import logging
 import math
 
 import pandas as pd
@@ -38,6 +39,7 @@ from ukwofost.core.parcel import Parcel
 from ukwofost.core.simulation_manager import WofostSimulator
 from ukwofost.core.utils import find_contiguous_sets
 
+logging.disable(logging.CRITICAL)
 
 def apply_conversion(df_row):
     """

--- a/bulk_wofost_simulator.py
+++ b/bulk_wofost_simulator.py
@@ -24,6 +24,7 @@ instances of the CropRotation class
 """
 
 import argparse
+import logging
 import math
 
 import pandas as pd
@@ -37,6 +38,7 @@ from ukwofost.core.defaults import (
 from ukwofost.core.simulation_manager import WofostSimulator
 from ukwofost.core.utils import find_contiguous_sets, lonlat2osgrid
 
+logging.disable(logging.CRITICAL)
 
 def apply_conversion(df_row):
     """

--- a/run_wofost.py
+++ b/run_wofost.py
@@ -25,15 +25,18 @@ values before passing the crop_params dictionary when the instance
 of the Crop class is instantiated (line 45). More information on
 agromanagment can be found at https://tinyurl.com/bdcmj5b7
 """
+import logging
 
 from ukwofost.core.crop_manager import Crop
 from ukwofost.core.defaults import defaults
 from ukwofost.core.parcel import Parcel
 from ukwofost.core.simulation_manager import WofostSimulator
-from ukwofost.core.utils import lonlat2osgrid
+# from ukwofost.core.utils import lonlat2osgrid
+
+logging.disable(logging.CRITICAL)
 
 # Define input parameters
-LON, LAT = -1.670330465465696, 55.028574354445425
+# LON, LAT = -1.670330465465696, 55.028574354445425
 CROP = "winter_wheat"
 YEAR = 2019
 PARCEL_ID = 578422
@@ -46,7 +49,7 @@ sim = WofostSimulator(
 
 crop_management = defaults.get("management").get(CROP)
 crop = Crop(calendar_year=YEAR, crop=CROP, **crop_management)
-crop_output = sim.run(crop_or_rotation=crop, output_flag="full")
+crop_output = sim.run(crop_or_rotation=crop, output_flag="summary")
 # # Define management
 # rotation = []
 # for item in zip(CROPS, YEARS):

--- a/run_wofost_parallel.py
+++ b/run_wofost_parallel.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2023 LEEP, University of Exeter (UK)
+# Mattia Mancini (m.c.mancini@exeter.ac.uk), January 2024
+# =======================================================
+"""
+run_wofost_parallel.py
+======================
+Test script based on ./run_wofost.py to run multiple instances of WOFOST
+in parallel using the multiprocessing library.
+
+INPUT PARAMETERS
+
+:param CROP: crop of interest
+:param YEAR: year of interest
+:param PARCEL_ID: ID of the parcel to be used for the simulation. This is
+    CEH LCM parcel IDs
+
+Crop details and agromanagment are loaded from a file containing
+default values for the specific crop. They can be overwritten
+to have user-sepcified values. This can be done in the section
+called "Define management", line 43 and following. The best option
+is to load the default crop parameters (line 44) and change their
+values before passing the crop_params dictionary when the instance
+of the Crop class is instantiated (line 45). More information on
+agromanagment can be found at https://tinyurl.com/bdcmj5b7
+"""
+import multiprocessing
+import logging
+from ukwofost.core.crop_manager import Crop
+from ukwofost.core.defaults import defaults
+from ukwofost.core.parcel import Parcel
+from ukwofost.core.simulation_manager import WofostSimulator
+
+logging.disable(logging.CRITICAL)
+
+# Input parameters
+CROP = "winter_wheat"
+YEAR = 2019
+PARCEL_ID = 578422
+
+# Create reusable data
+crop_management = defaults.get("management").get(CROP)
+
+# Function to run one simulation
+def run_single_simulation(sim_index):
+    """wrapper function to run a single wofost simulation"""
+    parcel = Parcel(PARCEL_ID)
+    sim = WofostSimulator(
+        location=parcel, weather_provider="Mesoclim", soil_provider="SoilGrids"
+    )
+    crop = Crop(calendar_year=YEAR, crop=CROP, **crop_management)
+    result = sim.run(crop_or_rotation=crop, output_flag="summary")
+    print(f"Simulation {sim_index} completed.")
+    return result
+
+if __name__ == "__main__":
+    NUM_SIMULATIONS = 10
+
+    with multiprocessing.Pool(processes=NUM_SIMULATIONS) as pool:
+        results = pool.map(run_single_simulation, range(NUM_SIMULATIONS))
+
+    for i, output in enumerate(results):
+        print(f"Sim {i}: Final TWSO = {output}")

--- a/ukwofost/data_providers/weather_manager.py
+++ b/ukwofost/data_providers/weather_manager.py
@@ -536,7 +536,7 @@ class ParcelWeatherDataProvider(WeatherDataProvider):
             f"Contact: {contact}",
         ]
 
-    # pylint: disable=W4902, R0914
+    # pylint: disable=W4902, R0914, R0912
     def _read_observations(self, csv_file, delimiter):
         """
         Processes the rows with meteo data and converts into the correct units.
@@ -622,7 +622,7 @@ class ParcelWeatherDataProvider(WeatherDataProvider):
                 msg = f"Failed computing a value for day '{day}' at row {i}"
                 self.logger.warn(msg)
 
-    # pylint: enable=W4902, R0914
+    # pylint: enable=W4902, R0914, R0912
 
     def _create_angstrom(self):
         """Find and assign Angstrom coefficients A and B"""


### PR DESCRIPTION
This PR addresses Issue #86 by deactivating pcse logging procedures at the environment level. This was required in order to be able to run multiple oinstances of Wofost in parallel; without this, Wofost would crash in the attempt of overwriting logging events on already open logs from a different wofost instance.   
As there does not appear to be a way of entirely switching off logging from within pcse, I ended up disabling logging at the environment level.  
The PR also includes a basic [test script](https://github.com/mcmancini/UkWofost/run_wofost_parallel.py) which can be used as a template.