### PR TITLE
Fix handling of connection errors to sql database

### DIFF
--- a/ukwofost/core/parcel.py
+++ b/ukwofost/core/parcel.py
@@ -88,8 +88,9 @@ class Parcel:
             dtm_data = get_dtm_values(os_code, app_config)["elevation"]
         except Exception as e:
             print(f"Error retrieving elevation for OS code {os_code}: {e}")
-            dtm_data = 0.
+            dtm_data = 0.0
         return round(dtm_data)
+
     # pylint: enable=W0718
 
     def _calc_spatial_attributes(self):

--- a/ukwofost/core/parcel.py
+++ b/ukwofost/core/parcel.py
@@ -80,14 +80,17 @@ class Parcel:
         """Set parcel elevation if exists"""
         return self._calc_elevation(self.osgrid_code)
 
+    # pylint: disable=W0718
     @staticmethod
     def _calc_elevation(os_code):
         """Retrieve elevation of the centroid of the parcel"""
         try:
-            elevation = round(get_dtm_values(os_code, app_config)["elevation"])
-        except ConnectionError:
-            elevation = 0
-        return elevation
+            dtm_data = get_dtm_values(os_code, app_config)["elevation"]
+        except Exception as e:
+            print(f"Error retrieving elevation for OS code {os_code}: {e}")
+            dtm_data = 0.
+        return round(dtm_data)
+    # pylint: enable=W0718
 
     def _calc_spatial_attributes(self):
         """

--- a/ukwofost/core/utils.py
+++ b/ukwofost/core/utils.py
@@ -751,17 +751,19 @@ def get_dtm_values(parcel_os_code, app_config):
     'x', 'y', 'elevation', 'slope', 'aspect'
     """
     # pylint: disable=R0914
-    db_name = app_config.dem_parameters["db_name"]
-    db_user = app_config.dem_parameters["username"]
-    db_password = app_config.dem_parameters["password"]
-
-    conn = None
 
     # retrieve lon, lat from parcel_os_code and create a bounding box to
     # find the closest 50m grid cell in the DEM
     lon, lat = osgrid2lonlat(parcel_os_code)
     lon_min, lon_max, lat_min, lat_max = lon - 50, lon + 50, lat - 50, lat + 50
+    conn = None
     try:
+        db_name = os.path.expandvars(app_config.dem_parameters.get("db_name", ""))
+        db_name = None if not db_name else db_name
+        db_user = os.path.expandvars(app_config.dem_parameters.get("username", ""))
+        db_user = None if not db_user else db_user
+        db_password = os.path.expandvars(app_config.dem_parameters.get("password", ""))
+        db_password = None if not db_password else db_password
         conn = psycopg2.connect(
             user=db_user,
             password=db_password,
@@ -798,13 +800,17 @@ def get_dtm_values(parcel_os_code, app_config):
         return dtm_dict
 
     except psycopg2.OperationalError as error:
-        print(f"Database connection failed: {error}")
-        return None
+        print(
+            f"WARNING: Database connection failed: {error}"
+            f" - returning default values."
+        )
+        return {"x": 0, "y": 0, "elevation": 0, "slope": 0, "aspect": 0}
 
+    #pylint: disable=W0718
     except Exception as error:
         print(f"An unexpected error occurred: {error}")
-        return None
-
+        return {"x": 0, "y": 0, "elevation": 0, "slope": 0, "aspect": 0}
+    #pylint: enable=W0718
     finally:
         if conn is not None:
             conn.close()

--- a/ukwofost/core/utils.py
+++ b/ukwofost/core/utils.py
@@ -758,11 +758,17 @@ def get_dtm_values(parcel_os_code, app_config):
     lon_min, lon_max, lat_min, lat_max = lon - 50, lon + 50, lat - 50, lat + 50
     conn = None
     try:
-        db_name = os.path.expandvars(app_config.dem_parameters.get("db_name", ""))
+        db_name = os.path.expandvars(
+            app_config.dem_parameters.get("db_name", "")
+        )
         db_name = None if not db_name else db_name
-        db_user = os.path.expandvars(app_config.dem_parameters.get("username", ""))
+        db_user = os.path.expandvars(
+            app_config.dem_parameters.get("username", "")
+        )
         db_user = None if not db_user else db_user
-        db_password = os.path.expandvars(app_config.dem_parameters.get("password", ""))
+        db_password = os.path.expandvars(
+            app_config.dem_parameters.get("password", "")
+        )
         db_password = None if not db_password else db_password
         conn = psycopg2.connect(
             user=db_user,
@@ -806,11 +812,11 @@ def get_dtm_values(parcel_os_code, app_config):
         )
         return {"x": 0, "y": 0, "elevation": 0, "slope": 0, "aspect": 0}
 
-    #pylint: disable=W0718
+    # pylint: disable=W0718
     except Exception as error:
         print(f"An unexpected error occurred: {error}")
         return {"x": 0, "y": 0, "elevation": 0, "slope": 0, "aspect": 0}
-    #pylint: enable=W0718
+    # pylint: enable=W0718
     finally:
         if conn is not None:
             conn.close()

--- a/ukwofost/core/utils.py
+++ b/ukwofost/core/utils.py
@@ -796,9 +796,15 @@ def get_dtm_values(parcel_os_code, app_config):
         dict_keys = ["x", "y", "elevation", "slope", "aspect"]
         dtm_dict = dtm_dict = dict(zip(dict_keys, dtm_vals))
         return dtm_dict
-    except psycopg2.DatabaseError as error:
-        print(error)
+
+    except psycopg2.OperationalError as error:
+        print(f"Database connection failed: {error}")
         return None
+
+    except Exception as error:
+        print(f"An unexpected error occurred: {error}")
+        return None
+
     finally:
         if conn is not None:
             conn.close()


### PR DESCRIPTION
This PR addresses Issue #89. The function `get_dtm_values()` to retrieve terrain data from a sql database did not deal with errors when connecting to the database properly and the try-except block would not prevent execution from breaking. This has now been fixed and tested.