### PR TITLE
Partial speedup: API + parallelization [#91]

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -56,9 +56,9 @@ jobs:
       - name: Setup SSH Key for MacOS server
         shell: powershell
         run: |
-          $env:DEPLOY_KEY = "${{ secrets.DEPLOY_KEY }}"
-          [System.IO.File]::WriteAllText("$HOME\.ssh\id_rsa_macos_cd", $env:DEPLOY_KEY, [System.Text.Encoding]::UTF8)
-          icacls $HOME\.ssh\id_rsa_macos_cd /inheritance:r /grant:r "$($env:USERNAME):F"
+          $env:DEPLOY_KEY = "${{ secrets.DEPLOY_UBUNTU_KEY }}" -replace "`r", ""
+          $env:DEPLOY_KEY | Out-File -Encoding ASCII -NoNewline $HOME\.ssh\id_rsa_ubuntu_cd
+          icacls $HOME\.ssh\id_rsa_ubuntu_cd /inheritance:r /grant:r "$($env:USERNAME):F"
 
       - name: Deploy to MacOS Server via SSH
         env:

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -56,8 +56,8 @@ jobs:
       - name: Setup SSH Key for MacOS server
         shell: powershell
         run: |
-          $env:DEPLOY_UBUNTU_KEY = "${{ secrets.DEPLOY_UBUNTU_KEY }}"
-          [System.IO.File]::WriteAllText("$HOME\.ssh\id_rsa_macos_cd", $env:DEPLOY_UBUNTU_KEY, [System.Text.Encoding]::UTF8)
+          $env:DEPLOY_KEY = "${{ secrets.DEPLOY_KEY }}"
+          [System.IO.File]::WriteAllText("$HOME\.ssh\id_rsa_macos_cd", $env:DEPLOY_KEY, [System.Text.Encoding]::UTF8)
           icacls $HOME\.ssh\id_rsa_macos_cd /inheritance:r /grant:r "$($env:USERNAME):F"
 
       - name: Deploy to MacOS Server via SSH

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -67,10 +67,10 @@ jobs:
         shell: powershell
         run: |
           ssh -i $HOME\.ssh\id_rsa_macos_cd $env:SERVER_USER@$env:SERVER_HOST `
-          "cd /Users/Shared/UkWofost && \
+          "cd ~/Documents/Github/UkWofost && \
           git pull origin dev && \
-          source /Users/Shared/miniconda3/etc/profile.d/conda.sh && \
-          conda env update -f /Users/Shared/UkWofost/wofost-env.yml --name wofost && \
+          source ~/miniconda3/etc/profile.d/conda.sh && \
+          conda env update -f ~/Documents/Github/UkWofost/wofost-env.yml --name wofost && \
           echo 'Model updated successfully!'"
 
       - name: Setup SSH Key for Ubuntu server

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -76,8 +76,8 @@ jobs:
       - name: Setup SSH Key for Ubuntu server
         shell: powershell
         run: |
-          $key = "${{ secrets.DEPLOY_UBUNTU_KEY }}"
-          [System.Convert]::FromBase64String($key) | Set-Content -Encoding Byte $HOME\.ssh\id_rsa_ubuntu_cd
+          $env:DEPLOY_UBUNTU_KEY = "${{ secrets.DEPLOY_UBUNTU_KEY }}" -replace "`r", ""
+          $env:DEPLOY_KEY | Out-File -Encoding ASCII -NoNewline $HOME\.ssh\id_rsa_ubuntu_cd
           icacls $HOME\.ssh\id_rsa_ubuntu_cd /inheritance:r /grant:r "$($env:USERNAME):F"
 
       - name: Deploy to Ubuntu Server via SSH

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -76,8 +76,8 @@ jobs:
       - name: Setup SSH Key for Ubuntu server
         shell: powershell
         run: |
-          $env:DEPLOY_UBUNTU_KEY = "${{ secrets.DEPLOY_UBUNTU_KEY }}" -replace "`r", ""
-          $env:DEPLOY_UBUNTU_KEY | Out-File -Encoding ASCII -NoNewline $HOME\.ssh\id_rsa_ubuntu_cd
+          $key = "${{ secrets.DEPLOY_UBUNTU_KEY }}"
+          [System.Convert]::FromBase64String($key) | Set-Content -Encoding Byte $HOME\.ssh\id_rsa_ubuntu_cd
           icacls $HOME\.ssh\id_rsa_ubuntu_cd /inheritance:r /grant:r "$($env:USERNAME):F"
 
       - name: Deploy to Ubuntu Server via SSH

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -56,8 +56,8 @@ jobs:
       - name: Setup SSH Key for MacOS server
         shell: powershell
         run: |
-          $env:DEPLOY_KEY = "${{ secrets.DEPLOY_KEY }}" -replace "`r", ""
-          $env:DEPLOY_KEY | Out-File -Encoding ASCII -NoNewline $HOME\.ssh\id_rsa_macos_cd
+          $env:DEPLOY_UBUNTU_KEY = "${{ secrets.DEPLOY_UBUNTU_KEY }}"
+          [System.IO.File]::WriteAllText("$HOME\.ssh\id_rsa_macos_cd", $env:DEPLOY_UBUNTU_KEY, [System.Text.Encoding]::UTF8)
           icacls $HOME\.ssh\id_rsa_macos_cd /inheritance:r /grant:r "$($env:USERNAME):F"
 
       - name: Deploy to MacOS Server via SSH
@@ -76,8 +76,8 @@ jobs:
       - name: Setup SSH Key for Ubuntu server
         shell: powershell
         run: |
-          $env:DEPLOY_UBUNTU_KEY = "${{ secrets.DEPLOY_UBUNTU_KEY }}" -replace "`r", ""
-          $env:DEPLOY_UBUNTU_KEY | Out-File -Encoding ASCII -NoNewline $HOME\.ssh\id_rsa_ubuntu_cd
+          $env:DEPLOY_UBUNTU_KEY = "${{ secrets.DEPLOY_UBUNTU_KEY }}"
+          [System.IO.File]::WriteAllText("$HOME\.ssh\id_rsa_ubuntu_cd", $env:DEPLOY_UBUNTU_KEY, [System.Text.Encoding]::UTF8)
           icacls $HOME\.ssh\id_rsa_ubuntu_cd /inheritance:r /grant:r "$($env:USERNAME):F"
 
       - name: Deploy to Ubuntu Server via SSH

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -87,7 +87,7 @@ jobs:
         shell: powershell
         run: |
           ssh -i $HOME\.ssh\id_rsa_ubuntu_cd $env:UBUNTU_SERVER_USER@$env:UBUNTU_SERVER_HOST `
-          "cd ~/Documents/GithubUkWofost && \
+          "cd ~/Documents/Github/UkWofost && \
           git pull origin dev && \
           source ~/miniconda3/etc/profile.d/conda.sh && \
           conda env update -f ~/Documents/Github/UkWofost/wofost-env.yml --name wofost && \

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -76,8 +76,8 @@ jobs:
       - name: Setup SSH Key for Ubuntu server
         shell: powershell
         run: |
-          $env:DEPLOY_UBUNTU_KEY = "${{ secrets.DEPLOY_UBUNTU_KEY }}" -replace "`r", ""
-          $env:DEPLOY_KEY | Out-File -Encoding ASCII -NoNewline $HOME\.ssh\id_rsa_ubuntu_cd
+          $key = "${{ secrets.DEPLOY_UBUNTU_KEY }}"
+          [System.Convert]::FromBase64String($key) | Set-Content -Encoding Byte $HOME\.ssh\id_rsa_ubuntu_cd
           icacls $HOME\.ssh\id_rsa_ubuntu_cd /inheritance:r /grant:r "$($env:USERNAME):F"
 
       - name: Deploy to Ubuntu Server via SSH

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -76,8 +76,8 @@ jobs:
       - name: Setup SSH Key for Ubuntu server
         shell: powershell
         run: |
-          $env:DEPLOY_KEY = "${{ secrets.DEPLOY_UBUNTU_KEY }}" -replace "`r", ""
-          $env:DEPLOY_KEY | Out-File -Encoding ASCII -NoNewline $HOME\.ssh\id_rsa_ubuntu_cd
+          $env:DEPLOY_UBUNTU_KEY = "${{ secrets.DEPLOY_UBUNTU_KEY }}" -replace "`r", ""
+          $env:DEPLOY_UBUNTU_KEY | Out-File -Encoding ASCII -NoNewline $HOME\.ssh\id_rsa_ubuntu_cd
           icacls $HOME\.ssh\id_rsa_ubuntu_cd /inheritance:r /grant:r "$($env:USERNAME):F"
 
       - name: Deploy to Ubuntu Server via SSH

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -88,7 +88,8 @@ jobs:
         run: |
           ssh -i $HOME\.ssh\id_rsa_ubuntu_cd $env:UBUNTU_SERVER_USER@$env:UBUNTU_SERVER_HOST `
           "cd ~/Documents/Github/UkWofost && \
-          git pull origin dev && \
+          git fetch origin dev && \
+          git reset --hard origin/dev && \
           source ~/miniconda3/etc/profile.d/conda.sh && \
           conda env update -f ~/Documents/Github/UkWofost/wofost-env.yml --name wofost && \
           echo 'Model updated successfully!'"

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -42,7 +42,7 @@ jobs:
     #     run: |
     #       python -m pytest --nbmake ./examples/examples.ipynb
   deploy:
-    # needs: build
+    needs: build
     runs-on: self-hosted
     if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
     steps:

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -3,36 +3,36 @@ name: macOS, Windows and Ubuntu Continuous Integration and Deployment pipeline
 on: [push, pull_request]
 
 jobs:
-  # build:
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     matrix:
-  #       node-version: [20.x]
-  #       os: [macOS-latest, windows-latest, ubuntu-latest]
-  #       python-version:
-  #         - 3.11.6
-  #   defaults:
-  #     run:
-  #       shell: bash -el {0}
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        node-version: [20.x]
+        os: [macOS-latest, windows-latest, ubuntu-latest]
+        python-version:
+          - 3.11.6
+    defaults:
+      run:
+        shell: bash -el {0}
 
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
 
-  #     - name: Configuring Conda
-  #       uses: conda-incubator/setup-miniconda@v2
-  #       with:
-  #         python-version: ${{ matrix.python-version }}
-  #         miniconda-version: "latest"
-  #         activate-environment: anaconda-client-env
-  #         environment-file: wofost-env.yml
-  #         auto-activate-base: false
+      - name: Configuring Conda
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+          miniconda-version: "latest"
+          activate-environment: anaconda-client-env
+          environment-file: wofost-env.yml
+          auto-activate-base: false
 
-  #     - name: Quality Assurance
-  #       run: |
-  #         python -m black --check ./ukwofost/
-  #         python -m flake8 ./ukwofost/ --count --show-source --statistics
-  #         python -m isort --apply .
+      - name: Quality Assurance
+        run: |
+          python -m black --check ./ukwofost/
+          python -m flake8 ./ukwofost/ --count --show-source --statistics
+          python -m isort --apply .
 
       # - name: Unit Testing
       #   run: |
@@ -44,7 +44,7 @@ jobs:
   deploy:
     # needs: build
     runs-on: self-hosted
-    # if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -49,13 +49,16 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
 
-      - name: Setup SSH Key
+      - name: Create SSH Directory
+        shell: powershell
+        run: mkdir -Force $HOME\.ssh
+
+      - name: Setup SSH Key for MacOS server
         shell: powershell
         run: |
-          mkdir -Force $HOME\.ssh
           $env:DEPLOY_KEY = "${{ secrets.DEPLOY_KEY }}" -replace "`r", ""
-          $env:DEPLOY_KEY | Out-File -Encoding ASCII -NoNewline $HOME\.ssh\id_rsa_github_CD
-          icacls $HOME\.ssh\id_rsa_github_CD /inheritance:r /grant:r "$($env:USERNAME):F"
+          $env:DEPLOY_KEY | Out-File -Encoding ASCII -NoNewline $HOME\.ssh\id_rsa_macos_cd
+          icacls $HOME\.ssh\id_rsa_macos_cd /inheritance:r /grant:r "$($env:USERNAME):F"
 
       - name: Deploy to MacOS Server via SSH
         env:
@@ -63,7 +66,27 @@ jobs:
           SERVER_HOST: ${{ secrets.SERVER_HOST }}
         shell: powershell
         run: |
-          ssh -i $HOME\.ssh\id_rsa_github_CD $env:SERVER_USER@$env:SERVER_HOST `
+          ssh -i $HOME\.ssh\id_rsa_macos_cd $env:SERVER_USER@$env:SERVER_HOST `
+          "cd /Users/Shared/UkWofost && \
+          git pull origin dev && \
+          source /Users/Shared/miniconda3/etc/profile.d/conda.sh && \
+          conda env update -f /Users/Shared/UkWofost/wofost-env.yml --name wofost && \
+          echo 'Model updated successfully!'"
+
+      - name: Setup SSH Key for Ubuntu server
+        shell: powershell
+        run: |
+          $env:DEPLOY_KEY = "${{ secrets.DEPLOY_UBUNTU_KEY }}" -replace "`r", ""
+          $env:DEPLOY_KEY | Out-File -Encoding ASCII -NoNewline $HOME\.ssh\id_rsa_ubuntu_cd
+          icacls $HOME\.ssh\id_rsa_ubuntu_cd /inheritance:r /grant:r "$($env:USERNAME):F"
+
+      - name: Deploy to Ubuntu Server via SSH
+        env:
+          UBUNTU_SERVER_USER: ${{ secrets.UBUNTU_SERVER_USER }}
+          UBUNTU_SERVER_HOST: ${{ secrets.UBUNTU_SERVER_HOST }}
+        shell: powershell
+        run: |
+          ssh -i $HOME\.ssh\id_rsa_ubuntu_cd $env:UBUNTU_SERVER_USER@$env:UBUNTU_SERVER_HOST `
           "cd /Users/Shared/UkWofost && \
           git pull origin dev && \
           source /Users/Shared/miniconda3/etc/profile.d/conda.sh && \

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -3,36 +3,36 @@ name: macOS, Windows and Ubuntu Continuous Integration and Deployment pipeline
 on: [push, pull_request]
 
 jobs:
-  build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        node-version: [20.x]
-        os: [macOS-latest, windows-latest, ubuntu-latest]
-        python-version:
-          - 3.11.6
-    defaults:
-      run:
-        shell: bash -el {0}
+  # build:
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     matrix:
+  #       node-version: [20.x]
+  #       os: [macOS-latest, windows-latest, ubuntu-latest]
+  #       python-version:
+  #         - 3.11.6
+  #   defaults:
+  #     run:
+  #       shell: bash -el {0}
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
 
-      - name: Configuring Conda
-        uses: conda-incubator/setup-miniconda@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-          miniconda-version: "latest"
-          activate-environment: anaconda-client-env
-          environment-file: wofost-env.yml
-          auto-activate-base: false
+  #     - name: Configuring Conda
+  #       uses: conda-incubator/setup-miniconda@v2
+  #       with:
+  #         python-version: ${{ matrix.python-version }}
+  #         miniconda-version: "latest"
+  #         activate-environment: anaconda-client-env
+  #         environment-file: wofost-env.yml
+  #         auto-activate-base: false
 
-      - name: Quality Assurance
-        run: |
-          python -m black --check ./ukwofost/
-          python -m flake8 ./ukwofost/ --count --show-source --statistics
-          python -m isort --apply .
+  #     - name: Quality Assurance
+  #       run: |
+  #         python -m black --check ./ukwofost/
+  #         python -m flake8 ./ukwofost/ --count --show-source --statistics
+  #         python -m isort --apply .
 
       # - name: Unit Testing
       #   run: |
@@ -42,7 +42,7 @@ jobs:
     #     run: |
     #       python -m pytest --nbmake ./examples/examples.ipynb
   deploy:
-    needs: build
+    # needs: build
     runs-on: self-hosted
     # if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
     steps:
@@ -76,10 +76,8 @@ jobs:
       - name: Setup SSH Key for Ubuntu server
         shell: powershell
         run: |
-          $env:DEPLOY_UBUNTU_KEY = "${{ secrets.DEPLOY_UBUNTU_KEY }}"
-          [System.IO.File]::WriteAllText("$HOME\.ssh\id_rsa_ubuntu_cd", $env:DEPLOY_UBUNTU_KEY, [System.Text.Encoding]::UTF8)
-          $env:DEPLOY_UBUNTU_KEY = "${{ secrets.DEPLOY_UBUNTU_KEY }}"
-          [System.IO.File]::WriteAllText("$HOME\.ssh\id_rsa_ubuntu_cd", $env:DEPLOY_UBUNTU_KEY, [System.Text.Encoding]::UTF8)
+          $env:DEPLOY_UBUNTU_KEY = "${{ secrets.DEPLOY_UBUNTU_KEY }}" -replace "`r", ""
+          $env:DEPLOY_UBUNTU_KEY | Out-File -Encoding ASCII -NoNewline $HOME\.ssh\id_rsa_ubuntu_cd
           icacls $HOME\.ssh\id_rsa_ubuntu_cd /inheritance:r /grant:r "$($env:USERNAME):F"
 
       - name: Deploy to Ubuntu Server via SSH

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -44,7 +44,7 @@ jobs:
   deploy:
     needs: build
     runs-on: self-hosted
-    if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
+    # if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -67,10 +67,10 @@ jobs:
         shell: powershell
         run: |
           ssh -i $HOME\.ssh\id_rsa_macos_cd $env:SERVER_USER@$env:SERVER_HOST `
-          "cd ~/Documents/Github/UkWofost && \
+          "cd /Users/Shared/UkWofost && \
           git pull origin dev && \
-          source ~/miniconda3/etc/profile.d/conda.sh && \
-          conda env update -f ~/Documents/Github/UkWofost/wofost-env.yml --name wofost && \
+          source /Users/Shared/miniconda3/etc/profile.d/conda.sh && \
+          conda env update -f /Users/Shared/UkWofost/wofost-env.yml --name wofost && \
           echo 'Model updated successfully!'"
 
       - name: Setup SSH Key for Ubuntu server
@@ -87,8 +87,8 @@ jobs:
         shell: powershell
         run: |
           ssh -i $HOME\.ssh\id_rsa_ubuntu_cd $env:UBUNTU_SERVER_USER@$env:UBUNTU_SERVER_HOST `
-          "cd /Users/Shared/UkWofost && \
+          "cd ~/Documents/GithubUkWofost && \
           git pull origin dev && \
-          source /Users/Shared/miniconda3/etc/profile.d/conda.sh && \
-          conda env update -f /Users/Shared/UkWofost/wofost-env.yml --name wofost && \
+          source ~/miniconda3/etc/profile.d/conda.sh && \
+          conda env update -f ~/Documents/Github/UkWofost/wofost-env.yml --name wofost && \
           echo 'Model updated successfully!'"

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -56,9 +56,9 @@ jobs:
       - name: Setup SSH Key for MacOS server
         shell: powershell
         run: |
-          $env:DEPLOY_KEY = "${{ secrets.DEPLOY_UBUNTU_KEY }}" -replace "`r", ""
-          $env:DEPLOY_KEY | Out-File -Encoding ASCII -NoNewline $HOME\.ssh\id_rsa_ubuntu_cd
-          icacls $HOME\.ssh\id_rsa_ubuntu_cd /inheritance:r /grant:r "$($env:USERNAME):F"
+          $env:DEPLOY_KEY = "${{ secrets.DEPLOY_KEY }}" -replace "`r", ""
+          $env:DEPLOY_KEY | Out-File -Encoding ASCII -NoNewline $HOME\.ssh\id_rsa_macos_cd
+          icacls $HOME\.ssh\id_rsa_macos_cd /inheritance:r /grant:r "$($env:USERNAME):F"
 
       - name: Deploy to MacOS Server via SSH
         env:

--- a/api/core/simulation.py
+++ b/api/core/simulation.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2025 LEEP, University of Exeter (UK)
+# Mattia Mancini (m.c.mancini@exeter.ac.uk), July 2025
+# ====================================================
+"""
+simulation.py
+=============
+Module for core business logic of running individual WOFOST simulations
+"""
+
+import pandas as pd
+
+from api.utils.utils import apply_conversion
+from ukwofost.core.crop_manager import Crop, CropBuilder
+from ukwofost.core.defaults import defaults, soil_parameters, wofost_parameters
+from ukwofost.core.parcel import Parcel
+from ukwofost.core.simulation_manager import WofostSimulator
+
+
+def run_wofost_simulation(run):
+    """Run an instance of a crop in WOFOST."""
+    parcel = run.parcel_id
+    try:
+        parcel_obj = Parcel(parcel)
+        sim = WofostSimulator(
+            location=parcel_obj,
+            weather_provider="Mesoclim",
+            soil_provider="SoilGrids",
+        )
+
+        parameter_dict = run.model_dump()
+
+        nonstandard_parameters = {
+            key: value
+            for key, value in parameter_dict.items()
+            if key in wofost_parameters or key in soil_parameters
+        }
+
+        try:
+            crop_args = CropBuilder(pd.Series(parameter_dict))
+            crop_params = crop_args.crop_parameters
+            crop_to_run = Crop(
+                crop_args.calendar_year,
+                crop_args.crop,
+                **crop_params,
+            )
+
+        except Exception as e:
+            print(f"[WARN] Falling back to default crop parameters: {e}")
+            crop_management = defaults.get("management").get(crop_args.crop)
+            crop_to_run = Crop(
+                crop_args.calendar_year, crop_args.crop, **crop_management
+            )
+
+        crop_output = sim.run(
+            crop_or_rotation=crop_to_run,
+            output_flag="full",
+            **nonstandard_parameters,
+        ).reset_index(drop=False)
+
+        # crop_list = [list(d.keys())[0] for d in crop_rotation.crop_list]
+        # crop_indices = find_contiguous_sets(crop_output, "LAI")
+        # crop_column = [
+        #     crop_list[index - 1] if index > 0 else "fallow"
+        #     for index in crop_indices
+        # ]
+        crop_output["crop"] = crop_to_run.crop
+        crop_output["parcel_id"] = parcel
+        crop_output["year"] = crop_to_run.calendar_year
+        crop_output["variety"] = crop_to_run.variety
+        crop_output["yield"] = crop_output.apply(
+            apply_conversion, axis=1
+        )
+
+        return crop_output
+
+    except Exception as e:
+        print(f"Error for parcel {parcel}: {e}")
+        return pd.DataFrame()

--- a/api/core/simulation.py
+++ b/api/core/simulation.py
@@ -17,7 +17,7 @@ from ukwofost.core.parcel import Parcel
 from ukwofost.core.simulation_manager import WofostSimulator
 
 
-def run_wofost_simulation(run):
+def run_wofost_simulation(run, summary):
     """Run an instance of a crop in WOFOST."""
     parcel = run.parcel_id
     try:
@@ -51,26 +51,35 @@ def run_wofost_simulation(run):
             crop_to_run = Crop(
                 crop_args.calendar_year, crop_args.crop, **crop_management
             )
-
-        crop_output = sim.run(
-            crop_or_rotation=crop_to_run,
-            output_flag="full",
-            **nonstandard_parameters,
-        ).reset_index(drop=False)
-
-        # crop_list = [list(d.keys())[0] for d in crop_rotation.crop_list]
-        # crop_indices = find_contiguous_sets(crop_output, "LAI")
-        # crop_column = [
-        #     crop_list[index - 1] if index > 0 else "fallow"
-        #     for index in crop_indices
-        # ]
-        crop_output["crop"] = crop_to_run.crop
-        crop_output["parcel_id"] = parcel
-        crop_output["year"] = crop_to_run.calendar_year
-        crop_output["variety"] = crop_to_run.variety
-        crop_output["yield"] = crop_output.apply(
-            apply_conversion, axis=1
-        )
+        if summary:
+            crop_yield = sim.run(
+                crop_or_rotation=crop_to_run,
+                output_flag="summary",
+                **nonstandard_parameters,
+            )
+            crop_output = pd.DataFrame(
+                [
+                    {
+                        "parcel_id": parcel,
+                        "crop": crop_to_run.crop,
+                        "year": crop_to_run.calendar_year,
+                        "variety": crop_to_run.variety,
+                        "TWSO": crop_yield,
+                    }
+                ]
+            )
+            crop_output["yield"] = crop_output.apply(apply_conversion, axis=1)
+        else:
+            crop_output = sim.run(
+                crop_or_rotation=crop_to_run,
+                output_flag="full",
+                **nonstandard_parameters,
+            ).reset_index(drop=False)
+            crop_output["crop"] = crop_to_run.crop
+            crop_output["parcel_id"] = parcel
+            crop_output["year"] = crop_to_run.calendar_year
+            crop_output["variety"] = crop_to_run.variety
+            crop_output["yield"] = crop_output.apply(apply_conversion, axis=1)
 
         return crop_output
 

--- a/api/endpoints/endpoints.py
+++ b/api/endpoints/endpoints.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2025 LEEP, University of Exeter (UK)
+# Mattia Mancini (m.c.mancini@exeter.ac.uk), July 2025
+# ====================================================
+"""
+enpoints.py
+===========
+This module defines the API endpoints for running crop simulations using
+the WOFOST model.
+"""
+
+from fastapi import APIRouter, HTTPException
+
+from api.models.crop import CropRequest
+from api.services.wofost_runner import run_crop_simulation
+
+router = APIRouter()
+
+
+@router.post("/run_crop")
+def run_crop(request: CropRequest):
+    """Run a WOFOST simulation for a crop in a specific year and parcel."""
+    try:
+        result = run_crop_simulation(
+            request.crop, request.year, request.parcel_id
+        )
+        return {"result": result}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e)) from e

--- a/api/endpoints/endpoints.py
+++ b/api/endpoints/endpoints.py
@@ -3,7 +3,7 @@
 # Mattia Mancini (m.c.mancini@exeter.ac.uk), July 2025
 # ====================================================
 """
-enpoints.py
+endpoints.py
 ===========
 This module defines the API endpoints for running crop simulations using
 the WOFOST model.
@@ -11,19 +11,27 @@ the WOFOST model.
 
 from fastapi import APIRouter, HTTPException
 
-from api.models.crop import CropRequest
-from api.services.wofost_runner import run_crop_simulation
+from api.models.crop import BulkRunner, SingleCrop
+from api.services.wofost_runner import run_from_payload, run_single_crop
 
 router = APIRouter()
 
 
 @router.post("/run_crop")
-def run_crop(request: CropRequest):
+def run_crop(request: SingleCrop):
     """Run a WOFOST simulation for a crop in a specific year and parcel."""
     try:
-        result = run_crop_simulation(
-            request.crop, request.year, request.parcel_id
-        )
+        result = run_single_crop(request.crop, request.year, request.parcel_id)
+        return {"result": result}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@router.post("/run_bulk")
+async def run_bulk(request: BulkRunner):
+    """Run bulk WOFOST simulations."""
+    try:
+        result = run_from_payload(request.runs)
         return {"result": result}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e)) from e

--- a/api/endpoints/endpoints.py
+++ b/api/endpoints/endpoints.py
@@ -28,10 +28,10 @@ def run_crop(request: SingleCrop):
 
 
 @router.post("/run_bulk")
-async def run_bulk(request: BulkRunner):
+async def run_bulk(request: BulkRunner, summary: bool = False):
     """Run bulk WOFOST simulations."""
     try:
-        result = run_from_payload(request.runs)
+        result = run_from_payload(request.runs, summary=summary)
         return {"result": result}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e)) from e

--- a/api/main.py
+++ b/api/main.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2025 LEEP, University of Exeter (UK)
+# Mattia Mancini (m.c.mancini@exeter.ac.uk), July 2025
+# ====================================================
+"""
+Wofost Yield Simulation API
+===========================
+
+This API allows users to run crop yield simulations using the WOFOST model
+passing a payload including input parameters such as crop type, year, and
+parcel ID. The API will return the simulated yield for the specified input.
+"""
+from fastapi import FastAPI
+
+from api.endpoints import endpoints
+
+app = FastAPI()
+app.include_router(endpoints.router)

--- a/api/models/crop.py
+++ b/api/models/crop.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2025 LEEP, University of Exeter (UK)
+# Mattia Mancini (m.c.mancini@exeter.ac.uk), July 2025
+# ====================================================
+"""
+Models required for API endpoint to run WOFOST simulations.
+"""
+from pydantic import BaseModel
+
+
+class CropRequest(BaseModel):
+    """
+    CropRequest model for API endpoint to run WOFOST simulations.
+    """
+
+    crop: str
+    year: int
+    parcel_id: int

--- a/api/models/crop.py
+++ b/api/models/crop.py
@@ -5,10 +5,12 @@
 """
 Models required for API endpoint to run WOFOST simulations.
 """
-from pydantic import BaseModel
+from typing import List
+
+from pydantic import BaseModel, ConfigDict
 
 
-class CropRequest(BaseModel):
+class SingleCrop(BaseModel):
     """
     CropRequest model for API endpoint to run WOFOST simulations.
     """
@@ -16,3 +18,22 @@ class CropRequest(BaseModel):
     crop: str
     year: int
     parcel_id: int
+
+
+class CropRunner(BaseModel):
+    """
+    CropRunner model for bulk WOFOST simulations.
+    """
+
+    parcel_id: int
+    crop: str
+    year: int
+    model_config = ConfigDict(extra="allow")
+
+
+class BulkRunner(BaseModel):
+    """
+    BulkRunner model for running multiple WOFOST simulations in bulk.
+    """
+
+    runs: List[CropRunner]

--- a/api/services/wofost_runner.py
+++ b/api/services/wofost_runner.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2025 LEEP, University of Exeter (UK)
+# Mattia Mancini (m.c.mancini@exeter.ac.uk), July 2025
+# ====================================================
+"""
+wofost_runner.py
+================
+"""
+import logging
+
+from ukwofost.core.crop_manager import Crop
+from ukwofost.core.defaults import defaults
+from ukwofost.core.parcel import Parcel
+from ukwofost.core.simulation_manager import WofostSimulator
+
+logging.disable(logging.CRITICAL)
+
+
+def run_crop_simulation(crop: str, year: int, parcel_id: int):
+    """Run a WOFOST simulation for a specific crop and year
+    at a given parcel.
+    """
+    parcel = Parcel(parcel_id)
+    sim = WofostSimulator(
+        location=parcel, weather_provider="Mesoclim", soil_provider="SoilGrids"
+    )
+    crop_management = defaults.get("management").get(crop)
+
+    if crop_management is None:
+        raise ValueError(f"Crop '{crop}' not found in defaults.")
+
+    crop_instance = Crop(calendar_year=year, crop=crop, **crop_management)
+    output = sim.run(crop_or_rotation=crop_instance, output_flag="summary")
+    return output

--- a/api/services/wofost_runner.py
+++ b/api/services/wofost_runner.py
@@ -47,6 +47,7 @@ def run_from_payload(
     runs: List[Union[dict, BaseModel]],
     parallel: bool = True,
     max_workers: int = os.cpu_count() - 1,
+    summary: bool = False,
 ) -> list:
     """
     Runs crop rotations simulations based on a list of parameter dicts.
@@ -69,7 +70,7 @@ def run_from_payload(
     if parallel:
         with ProcessPoolExecutor(max_workers=max_workers) as executor:
             futures = {
-                executor.submit(run_wofost_simulation, run): run_id
+                executor.submit(run_wofost_simulation, run, summary): run_id
                 for run_id, run in indexed_runs
             }
             for future in as_completed(futures):
@@ -80,7 +81,7 @@ def run_from_payload(
                     all_results.append(df_result)
     else:
         for run_id, run in indexed_runs:
-            df_result = run_wofost_simulation(run)
+            df_result = run_wofost_simulation(run, summary)
             if not df_result.empty:
                 df_result["run_id"] = run_id
                 all_results.append(df_result)

--- a/api/services/wofost_runner.py
+++ b/api/services/wofost_runner.py
@@ -7,7 +7,15 @@ wofost_runner.py
 ================
 """
 import logging
+import os
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from typing import List, Union
 
+import numpy as np
+import pandas as pd
+from pydantic import BaseModel
+
+from api.core.simulation import run_wofost_simulation
 from ukwofost.core.crop_manager import Crop
 from ukwofost.core.defaults import defaults
 from ukwofost.core.parcel import Parcel
@@ -16,9 +24,10 @@ from ukwofost.core.simulation_manager import WofostSimulator
 logging.disable(logging.CRITICAL)
 
 
-def run_crop_simulation(crop: str, year: int, parcel_id: int):
-    """Run a WOFOST simulation for a specific crop and year
-    at a given parcel.
+def run_single_crop(crop: str, year: int, parcel_id: int):
+    """
+    Run a WOFOST simulation for a specific crop and year
+    at a given parcel with standard managment.
     """
     parcel = Parcel(parcel_id)
     sim = WofostSimulator(
@@ -32,3 +41,55 @@ def run_crop_simulation(crop: str, year: int, parcel_id: int):
     crop_instance = Crop(calendar_year=year, crop=crop, **crop_management)
     output = sim.run(crop_or_rotation=crop_instance, output_flag="summary")
     return output
+
+
+def run_from_payload(
+    runs: List[Union[dict, BaseModel]],
+    parallel: bool = True,
+    max_workers: int = os.cpu_count() - 1,
+) -> list:
+    """
+    Runs crop rotations simulations based on a list of parameter dicts.
+
+    Args:
+        runs: List of dicts, each dict is a set of input parameters for
+        one row.
+        parallel: Whether to run in parallel.
+        max_workers: Number of worker processes for parallel execution.
+
+    Returns:
+        List of dicts with simulation results, JSON-serializable.
+    """
+
+    all_results = []
+
+    # Attach an index to every run so we can trace it
+    indexed_runs = [(f"run{i+1}", run) for i, run in enumerate(runs)]
+
+    if parallel:
+        with ProcessPoolExecutor(max_workers=max_workers) as executor:
+            futures = {
+                executor.submit(run_wofost_simulation, run): run_id
+                for run_id, run in indexed_runs
+            }
+            for future in as_completed(futures):
+                run_id = futures[future]
+                df_result = future.result()
+                if not df_result.empty:
+                    df_result["run_id"] = run_id
+                    all_results.append(df_result)
+    else:
+        for run_id, run in indexed_runs:
+            df_result = run_wofost_simulation(run)
+            if not df_result.empty:
+                df_result["run_id"] = run_id
+                all_results.append(df_result)
+
+    if all_results:
+        final_df = pd.concat(all_results, ignore_index=True)
+        final_df.replace(
+            {np.nan: None, np.inf: None, -np.inf: None}, inplace=True
+        )
+        return final_df.to_dict(orient="records")
+    else:
+        return []

--- a/api/utils/utils.py
+++ b/api/utils/utils.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2025 LEEP, University of Exeter (UK)
+# Mattia Mancini (m.c.mancini@exeter.ac.uk), July 2025
+# ====================================================
+"""
+utils.py
+===========
+Utility module for the API
+"""
+
+import math
+
+from ukwofost.core.defaults import moisture_adjustment
+
+
+def apply_conversion(df_row):
+    """
+    Function to convert yields in kg DM to kg at standard harvest moisture
+    """
+    try:
+        twso = df_row["TWSO"]
+        crop = df_row["crop"]
+
+        if isinstance(twso, float) and math.isnan(twso):
+            return None
+
+        return twso / (1 - moisture_adjustment.get(crop, 0))
+    except TypeError:
+        return None

--- a/bulk_parcel_simulator.py
+++ b/bulk_parcel_simulator.py
@@ -41,6 +41,7 @@ from ukwofost.core.utils import find_contiguous_sets
 
 logging.disable(logging.CRITICAL)
 
+
 def apply_conversion(df_row):
     """
     Function to convert yields in kg DM to kg at standard harvest moisture
@@ -76,9 +77,7 @@ def run_rotations(input_sample_df, output_filename):
             weather_provider="Mesoclim",
             soil_provider="SoilGrids",
         )
-        parcel_df = input_sample_df[
-            (input_sample_df["parcel_id"] == parcel)
-        ]
+        parcel_df = input_sample_df[(input_sample_df["parcel_id"] == parcel)]
 
         # Iterate over rotations
         for rotation in parcel_df["rotation"].unique():

--- a/bulk_wofost_simulator.py
+++ b/bulk_wofost_simulator.py
@@ -40,6 +40,7 @@ from ukwofost.core.utils import find_contiguous_sets, lonlat2osgrid
 
 logging.disable(logging.CRITICAL)
 
+
 def apply_conversion(df_row):
     """
     Function to convert yields in kg DM to kg at standard harvest moisture

--- a/generate_memory.py
+++ b/generate_memory.py
@@ -16,8 +16,9 @@ crops and all parcels of the farm of interest for a number of years equal
 to the predefined length of the memory of the farmer of interest.
 """
 import numpy as np
-from tqdm import tqdm
 import xarray as xr
+from tqdm import tqdm
+
 from ukwofost.core.crop_manager import Crop
 from ukwofost.core.crops import Crops
 from ukwofost.core.defaults import defaults
@@ -57,6 +58,6 @@ if __name__ == "__main__":
     memory = get_wofost_yields(
         sim_start_time=START_YEAR,
         memory_length=YEARS_IN_MEMORY,
-        parcel_ids=parcels
+        parcel_ids=parcels,
     )
     memory.to_netcdf("memory.nc")

--- a/run_wofost.py
+++ b/run_wofost.py
@@ -31,6 +31,7 @@ from ukwofost.core.crop_manager import Crop
 from ukwofost.core.defaults import defaults
 from ukwofost.core.parcel import Parcel
 from ukwofost.core.simulation_manager import WofostSimulator
+
 # from ukwofost.core.utils import lonlat2osgrid
 
 logging.disable(logging.CRITICAL)

--- a/run_wofost_parallel.py
+++ b/run_wofost_parallel.py
@@ -24,8 +24,9 @@ values before passing the crop_params dictionary when the instance
 of the Crop class is instantiated (line 45). More information on
 agromanagment can be found at https://tinyurl.com/bdcmj5b7
 """
-import multiprocessing
 import logging
+import multiprocessing
+
 from ukwofost.core.crop_manager import Crop
 from ukwofost.core.defaults import defaults
 from ukwofost.core.parcel import Parcel
@@ -41,6 +42,7 @@ PARCEL_ID = 578422
 # Create reusable data
 crop_management = defaults.get("management").get(CROP)
 
+
 # Function to run one simulation
 def run_single_simulation(sim_index):
     """wrapper function to run a single wofost simulation"""
@@ -52,6 +54,7 @@ def run_single_simulation(sim_index):
     result = sim.run(crop_or_rotation=crop, output_flag="summary")
     print(f"Simulation {sim_index} completed.")
     return result
+
 
 if __name__ == "__main__":
     NUM_SIMULATIONS = 10

--- a/test_api.py
+++ b/test_api.py
@@ -13,8 +13,8 @@ import numpy as np
 import requests
 
 df = pd.read_csv(
-    "C:/Users/mcm216/OneDrive - University of Exeter/",
-    "Desktop/WofostSimulator/wofost-new-rotation_1.csv",
+    "C:/Users/mcm216/OneDrive - University of Exeter/"
+    + "Desktop/WofostSimulator/wofost-new-rotation_1.csv",
 )
 df = df.replace({np.nan: None, np.inf: None, -np.inf: None})
 
@@ -22,9 +22,10 @@ df = df.replace({np.nan: None, np.inf: None, -np.inf: None})
 # Convert the DataFrame to the expected JSON format
 payload = {"runs": df.to_dict(orient="records")}
 
+summary_flag = True
 # URL of your local FastAPI endpoint
-url = "http://127.0.0.1:8000/run_bulk"
+URL = f"http://127.0.0.1:8000/run_bulk?summary={str(summary_flag).lower()}"
 
 # Send the POST request
-response = requests.post(url, json=payload)
+response = requests.post(URL, json=payload, timeout=60)
 df = pd.DataFrame(response.json()["result"])

--- a/test_api.py
+++ b/test_api.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2025 LEEP, University of Exeter (UK)
+# Mattia Mancini (m.c.mancini@exeter.ac.uk), July 2025
+# ====================================================
+"""
+test_api.py
+===========
+This module contains tests for the API endpoints related to WOFOST simulations.
+"""
+
+import pandas as pd
+import numpy as np
+import requests
+
+df = pd.read_csv(
+    "C:/Users/mcm216/OneDrive - University of Exeter/",
+    "Desktop/WofostSimulator/wofost-new-rotation_1.csv",
+)
+df = df.replace({np.nan: None, np.inf: None, -np.inf: None})
+
+
+# Convert the DataFrame to the expected JSON format
+payload = {"runs": df.to_dict(orient="records")}
+
+# URL of your local FastAPI endpoint
+url = "http://127.0.0.1:8000/run_bulk"
+
+# Send the POST request
+response = requests.post(url, json=payload)
+df = pd.DataFrame(response.json()["result"])

--- a/wofost-env.yml
+++ b/wofost-env.yml
@@ -4,6 +4,7 @@ channels:
   - defaults
 dependencies:
   - black
+  - fastapi
   - flake8
   - gdal
   - geopandas
@@ -19,6 +20,7 @@ dependencies:
   - pyyaml
   - sqlalchemy
   - tqdm
+  - uvicorn
   - xarray
   - yaml
   - pip:


### PR DESCRIPTION
With this PR I created a small FastAPI app that can run either locally or on a server and that takes a JSON payload to run run WOFOST. There are two endpoints currently implemented:  
1. `/run_crop` which required to pass a crop, a year for which the crop must be run, and the ID of a parcel on which to run the crop. This will return the crop yield in dry matter;
2. `/run_bulk` which allows to run one or multiple instances of WOFOST at once with user-defined initial soil and nutrient conditions, management, or crop parameters. This is set up similarly to [bulk_parcel_simulator.py](https://github.com/mcmancini/UkWofost/blob/dev/bulk_parcel_simulator.py)
removing rotations as they are no longer needed at the moment. There are two ways of calling this endpoint:  
    - `/run_bulk` will return the full daily output for all state variables tracked in the simulations;
    - `/run_bulk?summary=true` will only return the final crop yield for each of the simulations.  

This PR partially addresses Issue #91 where we attempt to speed up the execution of Wofost for model emulation and calibration.