### PR TITLE
Fixed API bug where some of the custom POST payload parameters would not be read 

### DIFF
--- a/api/models/crop.py
+++ b/api/models/crop.py
@@ -28,6 +28,7 @@ class CropRunner(BaseModel):
     parcel_id: int
     crop: str
     year: int
+    variety: str
     model_config = ConfigDict(extra="allow")
 
 

--- a/wofost-env.yml
+++ b/wofost-env.yml
@@ -14,6 +14,7 @@ dependencies:
   - pandas
   - pip
   - psycopg2
+  - pydantic>=2.0
   - pylint
   - pyproj
   - python=3.11.6


### PR DESCRIPTION
This PR addresses Issue #99. This is a bug where on Windows the payload passed to the Pydantic model CropRunner is read and interpreted correctly, whereas it is not on Ubuntu. In particular, on Ubuntu, some of the parameters would not be passed (for example the crop variety), and the model would fall back to default ones.
It turns out the issue was the fact that installing fastapi and uvicorn on Ubuntu would by default install pydantic 1, rather than 2. Upgrading to Pydantic 2 and explicity declare a 'variety' parameter in the CropRunner model fixed the issue.