### PR TITLE
Add option of returning output only for harvest date

### DIFF
--- a/api/core/simulation.py
+++ b/api/core/simulation.py
@@ -17,7 +17,7 @@ from ukwofost.core.parcel import Parcel
 from ukwofost.core.simulation_manager import WofostSimulator
 
 
-def run_wofost_simulation(run, output_mode:str):
+def run_wofost_simulation(run, output_mode: str):
     """Run an instance of a crop in WOFOST."""
     parcel = run.parcel_id
     try:
@@ -91,7 +91,6 @@ def run_wofost_simulation(run, output_mode:str):
             if output_mode == "harvest":
                 max_idx = crop_output["yield"].idxmax()
                 crop_output = crop_output.loc[[max_idx]]
-
 
         return crop_output
 

--- a/api/core/simulation.py
+++ b/api/core/simulation.py
@@ -17,7 +17,7 @@ from ukwofost.core.parcel import Parcel
 from ukwofost.core.simulation_manager import WofostSimulator
 
 
-def run_wofost_simulation(run, summary):
+def run_wofost_simulation(run, output_mode:str):
     """Run an instance of a crop in WOFOST."""
     parcel = run.parcel_id
     try:
@@ -59,7 +59,7 @@ def run_wofost_simulation(run, summary):
             crop_to_run = Crop(
                 crop_args.calendar_year, crop_args.crop, **crop_management
             )
-        if summary:
+        if output_mode == "summary":
             crop_yield = sim.run(
                 crop_or_rotation=crop_to_run,
                 output_flag="summary",
@@ -88,6 +88,10 @@ def run_wofost_simulation(run, summary):
             crop_output["year"] = crop_to_run.calendar_year
             crop_output["variety"] = crop_to_run.variety
             crop_output["yield"] = crop_output.apply(apply_conversion, axis=1)
+            if output_mode == "harvest":
+                max_idx = crop_output["yield"].idxmax()
+                crop_output = crop_output.loc[[max_idx]]
+
 
         return crop_output
 

--- a/api/endpoints/endpoints.py
+++ b/api/endpoints/endpoints.py
@@ -28,10 +28,12 @@ def run_crop(request: SingleCrop):
 
 
 @router.post("/run_bulk")
-async def run_bulk(request: BulkRunner, summary: bool = False):
+async def run_bulk(request: BulkRunner, summary: str = "harvest"):
     """Run bulk WOFOST simulations."""
     try:
         result = run_from_payload(request.runs, summary=summary)
         return {"result": result}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e)) from e
+    
+

--- a/api/endpoints/endpoints.py
+++ b/api/endpoints/endpoints.py
@@ -35,5 +35,3 @@ async def run_bulk(request: BulkRunner, summary: str = "harvest"):
         return {"result": result}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e)) from e
-    
-

--- a/api/services/wofost_runner.py
+++ b/api/services/wofost_runner.py
@@ -47,7 +47,7 @@ def run_from_payload(
     runs: List[Union[dict, BaseModel]],
     parallel: bool = True,
     max_workers: int = os.cpu_count() - 1,
-    summary: bool = False,
+    summary: str = "harvest",
 ) -> list:
     """
     Runs crop rotations simulations based on a list of parameter dicts.

--- a/test_api.py
+++ b/test_api.py
@@ -22,7 +22,7 @@ df = df.replace({np.nan: None, np.inf: None, -np.inf: None})
 # Convert the DataFrame to the expected JSON format
 payload = {"runs": df.to_dict(orient="records")}
 
-SUMMARY_FLAG = "harvest" # can be "full", "summary" or "harvest"
+SUMMARY_FLAG = "harvest"  # can be "full", "summary" or "harvest"
 # URL of your local FastAPI endpoint
 # URL = f"http://mmlin.ex.ac.uk:8000/run_bulk?summary={str(SUMMARY_FLAG).lower()}"
 URL = f"http://localhost:8000/run_bulk?summary={str(SUMMARY_FLAG).lower()}"

--- a/test_api.py
+++ b/test_api.py
@@ -22,9 +22,10 @@ df = df.replace({np.nan: None, np.inf: None, -np.inf: None})
 # Convert the DataFrame to the expected JSON format
 payload = {"runs": df.to_dict(orient="records")}
 
-summary_flag = True
+SUMMARY_FLAG = "harvest" # can be "full", "summary" or "harvest"
 # URL of your local FastAPI endpoint
-URL = f"http://127.0.0.1:8000/run_bulk?summary={str(summary_flag).lower()}"
+# URL = f"http://mmlin.ex.ac.uk:8000/run_bulk?summary={str(SUMMARY_FLAG).lower()}"
+URL = f"http://localhost:8000/run_bulk?summary={str(SUMMARY_FLAG).lower()}"
 
 # Send the POST request
 response = requests.post(URL, json=payload, timeout=60)

--- a/ukwofost/core/utils.py
+++ b/ukwofost/core/utils.py
@@ -769,9 +769,7 @@ def get_dtm_values(parcel_os_code, app_config):
         db_password = os.path.expandvars(
             app_config.dem_parameters.get("password", "")
         )
-        db_host = os.path.expandvars(
-            app_config.dem_parameters.get("host", "")
-        )
+        db_host = os.path.expandvars(app_config.dem_parameters.get("host", ""))
         db_password = None if not db_password else db_password
         conn = psycopg2.connect(
             user=db_user,

--- a/ukwofost/core/utils.py
+++ b/ukwofost/core/utils.py
@@ -769,12 +769,15 @@ def get_dtm_values(parcel_os_code, app_config):
         db_password = os.path.expandvars(
             app_config.dem_parameters.get("password", "")
         )
+        db_host = os.path.expandvars(
+            app_config.dem_parameters.get("host", "")
+        )
         db_password = None if not db_password else db_password
         conn = psycopg2.connect(
             user=db_user,
             password=db_password,
             database=db_name,
-            host="127.0.0.1",
+            host=db_host,
             port="5432",
         )
         conn.autocommit = True


### PR DESCRIPTION
This PR addresses Issue #103 by altering the 'run_bulk' endpoint of the FastAPI app which now can take the following argument options to process and return output:  
1) `"full"`: this returns the full time series of crop state variables till harvest time for each run defined in the payload;
2) `"harvest"`: this returns all crop state variables for the day in which the crop is harvested;
3) `"summary"`: this only returns the crop yield.  

Option 2 will reduce the amount of data to be passed from the host to the clients when preparing data to train the emulators of the management optimiser.