### PR TITLE
Bug fixes in `run_bulk` API endpoint

### DIFF
--- a/api/core/simulation.py
+++ b/api/core/simulation.py
@@ -9,6 +9,7 @@ Module for core business logic of running individual WOFOST simulations
 """
 
 import pandas as pd
+from typing import Literal
 
 from api.utils.utils import apply_conversion
 from ukwofost.core.crop_manager import Crop, CropBuilder
@@ -17,7 +18,10 @@ from ukwofost.core.parcel import Parcel
 from ukwofost.core.simulation_manager import WofostSimulator
 
 
-def run_wofost_simulation(run, output_mode: str):
+def run_wofost_simulation(
+    run,
+    output_mode: Literal["harvest", "full", "summary"],
+):
     """Run an instance of a crop in WOFOST."""
     parcel = run.parcel_id
     try:
@@ -35,7 +39,7 @@ def run_wofost_simulation(run, output_mode: str):
             try:
                 parameter_dict = run.dict()
             except AttributeError:
-                # last resort: try to coerce dataclass or simple object via vars()
+                # last resort: try to coerce dataclass or object via vars()
                 parameter_dict = dict(vars(run))
 
         nonstandard_parameters = {

--- a/api/endpoints/endpoints.py
+++ b/api/endpoints/endpoints.py
@@ -10,6 +10,7 @@ the WOFOST model.
 """
 
 from fastapi import APIRouter, HTTPException
+from typing import Literal
 
 from api.models.crop import BulkRunner, SingleCrop
 from api.services.wofost_runner import run_from_payload, run_single_crop
@@ -28,7 +29,9 @@ def run_crop(request: SingleCrop):
 
 
 @router.post("/run_bulk")
-async def run_bulk(request: BulkRunner, summary: str = "harvest"):
+async def run_bulk(
+    request: BulkRunner, summary: Literal["harvest", "full", "summary"]
+):
     """Run bulk WOFOST simulations."""
     try:
         result = run_from_payload(request.runs, summary=summary)

--- a/api/services/wofost_runner.py
+++ b/api/services/wofost_runner.py
@@ -9,7 +9,7 @@ wofost_runner.py
 import logging
 import os
 from concurrent.futures import ProcessPoolExecutor, as_completed
-from typing import List, Union
+from typing import List, Union, Literal
 
 import numpy as np
 import pandas as pd
@@ -45,9 +45,9 @@ def run_single_crop(crop: str, year: int, parcel_id: int):
 
 def run_from_payload(
     runs: List[Union[dict, BaseModel]],
+    summary: Literal["harvest", "full", "summary"],
     parallel: bool = True,
     max_workers: int = os.cpu_count() - 1,
-    summary: str = "harvest",
 ) -> list:
     """
     Runs crop rotations simulations based on a list of parameter dicts.

--- a/test_api.py
+++ b/test_api.py
@@ -24,8 +24,8 @@ payload = {"runs": df.to_dict(orient="records")}
 
 SUMMARY_FLAG = "harvest"  # can be "full", "summary" or "harvest"
 # URL of your local FastAPI endpoint
-# URL = f"http://mmlin.ex.ac.uk:8000/run_bulk?summary={str(SUMMARY_FLAG).lower()}"
-URL = f"http://localhost:8000/run_bulk?summary={str(SUMMARY_FLAG).lower()}"
+# URL = f"http://mmlin.ex.ac.uk:8000/run_bulk?summary={SUMMARY_FLAG}"
+URL = f"http://localhost:8000/run_bulk?summary={SUMMARY_FLAG}"
 
 # Send the POST request
 response = requests.post(URL, json=payload, timeout=60)


### PR DESCRIPTION
Bug fixes in the API enpoint `run_bulk` where, if the argument "summary" was not declared in the payload, the simulation would default to "harvest". Now we have a check that ensures `summary` must be passed and enforces value checks