### PR TITLE
Load parcels from SQL database rather than from shapefiles

### DIFF
--- a/api/core/simulation.py
+++ b/api/core/simulation.py
@@ -8,8 +8,9 @@ simulation.py
 Module for core business logic of running individual WOFOST simulations
 """
 
-import pandas as pd
 from typing import Literal
+
+import pandas as pd
 
 from api.utils.utils import apply_conversion
 from ukwofost.core.crop_manager import Crop, CropBuilder

--- a/api/endpoints/endpoints.py
+++ b/api/endpoints/endpoints.py
@@ -9,8 +9,9 @@ This module defines the API endpoints for running crop simulations using
 the WOFOST model.
 """
 
-from fastapi import APIRouter, HTTPException
 from typing import Literal
+
+from fastapi import APIRouter, HTTPException
 
 from api.models.crop import BulkRunner, SingleCrop
 from api.services.wofost_runner import run_from_payload, run_single_crop

--- a/api/services/wofost_runner.py
+++ b/api/services/wofost_runner.py
@@ -9,7 +9,7 @@ wofost_runner.py
 import logging
 import os
 from concurrent.futures import ProcessPoolExecutor, as_completed
-from typing import List, Union, Literal
+from typing import List, Literal, Union
 
 import numpy as np
 import pandas as pd

--- a/config.ini.example
+++ b/config.ini.example
@@ -1,8 +1,8 @@
-[dem_parameters]
-db_name = terrain_50
-host = localhost
-username = ${SQL_user}
-password = ${SQL_pwd}
+[dbm_parameters]
+db_name = england_landcover
+host = database_host
+username = username
+password = password
 port = 5432
 
 [data_dirs]

--- a/test_api.py
+++ b/test_api.py
@@ -8,8 +8,8 @@ test_api.py
 This module contains tests for the API endpoints related to WOFOST simulations.
 """
 
-import pandas as pd
 import numpy as np
+import pandas as pd
 import requests
 
 df = pd.read_csv(

--- a/ukwofost/core/parcel.py
+++ b/ukwofost/core/parcel.py
@@ -13,10 +13,12 @@ WofostSimulator objects.
 import os
 import warnings
 
-import geopandas as gpd
-
 from ukwofost.core import app_config
-from ukwofost.core.utils import get_dtm_values, lonlat2osgrid
+from ukwofost.core.utils import (
+    get_dtm_values,
+    load_parcel_from_db,
+    lonlat2osgrid,
+)
 
 
 class Parcel:
@@ -98,10 +100,12 @@ class Parcel:
         Compute OS grid code of the centroid
         of the parcel with id = "parcel_id"
         """
-        parcels_shapefile = gpd.read_file(self._PARCEL_DATA)
+        parcels_shapefile = load_parcel_from_db(self.parcel_id, app_config)
+        parcels_shapefile = parcels_shapefile.to_crs(epsg=4326)
         parcel_centroid = parcels_shapefile[
             parcels_shapefile["gid"] == str(self.parcel_id)
         ].centroid
+        parcel_centroid = parcel_centroid.to_crs("EPSG:4326")
         lon, lat = (parcel_centroid.iloc[0].x, parcel_centroid.iloc[0].y)
         osgrid_code = lonlat2osgrid(coords=(lon, lat), figs=8)
         return {

--- a/ukwofost/core/utils.py
+++ b/ukwofost/core/utils.py
@@ -95,12 +95,16 @@ estimate_angstrom(toa=None, toc=None):
     Determine Angstrom A/B parameters from Top-of-Atmosphere and
     top-of-Canopy radiation values if present.
 
+load_parcel_from_db(parcel_gid, app_config):
+    Query a parcel database to retrieve parcel data
+
 """
 
 import json
 import math
 import os
 import re
+import urllib
 from datetime import date, datetime, time, timedelta
 from math import acos, asin, cos
 from math import degrees as deg
@@ -108,10 +112,12 @@ from math import exp, floor, log
 from math import radians as rad
 from math import sin, tan
 
+import geopandas as gpd
 import numpy as np
 import pandas as pd
 import psycopg2
 from pyproj import Transformer
+from sqlalchemy import create_engine
 
 
 class BNGError(Exception):
@@ -759,17 +765,17 @@ def get_dtm_values(parcel_os_code, app_config):
     conn = None
     try:
         db_name = os.path.expandvars(
-            app_config.dem_parameters.get("db_name", "")
+            app_config.db_parameters.get("db_name", "")
         )
         db_name = None if not db_name else db_name
         db_user = os.path.expandvars(
-            app_config.dem_parameters.get("username", "")
+            app_config.db_parameters.get("username", "")
         )
         db_user = None if not db_user else db_user
         db_password = os.path.expandvars(
-            app_config.dem_parameters.get("password", "")
+            app_config.db_parameters.get("password", "")
         )
-        db_host = os.path.expandvars(app_config.dem_parameters.get("host", ""))
+        db_host = os.path.expandvars(app_config.db_parameters.get("host", ""))
         db_password = None if not db_password else db_password
         conn = psycopg2.connect(
             user=db_user,
@@ -1001,3 +1007,58 @@ def estimate_angstrom(toa=None, toc=None):
         )
         msg = msg % (angstrom_a, angstrom_b, e)
     return angstrom_a, angstrom_b
+
+
+def load_parcel_from_db(parcel_gid, app_config):
+    """
+    Query a parcel database to retrieve parcel data
+
+    Parameters
+    ----------
+    :param parcel_gid: The ID of the parcel to retrieve
+    :param app_config: The application configuration object
+
+    Return
+    ------
+    :return: GeoDataFrame containing the parcel data
+    """
+
+    # pylint: disable=W0718
+    conn = None
+    try:
+        db_name = os.path.expandvars(
+            app_config.db_parameters.get("db_name", "")
+        )
+        db_name = None if not db_name else db_name
+        db_user = os.path.expandvars(
+            app_config.db_parameters.get("username", "")
+        )
+        db_user = None if not db_user else db_user
+        db_password = os.path.expandvars(
+            app_config.db_parameters.get("password", "")
+        )
+        db_host = os.path.expandvars(app_config.db_parameters.get("host", ""))
+        db_password = (
+            None if not db_password else urllib.parse.quote_plus(db_password)
+        )
+        conn = (
+            "postgresql+psycopg2://"
+            f"{db_user}:{db_password}@{db_host}:5432/{db_name}"
+        )
+        engine = create_engine(conn)
+        sql = f"""
+            SELECT * FROM parcels.parcels WHERE gid = '{parcel_gid}';
+        """
+        with engine.connect() as connection:
+            sql_return = gpd.read_postgis(sql, connection, geom_col="geom")
+        # cur.execute(sql)
+        # sql_return = cur.fetchall()
+        # if len(sql_return) == 0:
+        #     raise ValueError(f"Parcel with gid {parcel_gid} not found in DB")
+        parcel_data = sql_return
+        return parcel_data
+    except psycopg2.OperationalError as error:
+        print(f"WARNING: Database connection failed: {error}")
+    except Exception as error:
+        print(f"An unexpected error occurred: {error}")
+    # pylint: enable=W0718


### PR DESCRIPTION
Building parcels to run WOFOST required querying a shapefile containing spatial information about all parcels in the UK. This was clunky and time consuming, as well as inefficient for data storage. Now the parcel data has been moved into a postgreSQL-postGIS database with indexing  on parcel IDs which makes it much more efficient. Parcel data is stored in the same database where the elevation data is contained, which needs to be specified in the 'config.ini' file created from the `config.ini.example` template configuration file.