### PR TITLE
Refactor the code to allow multiple concurrent connections from the UkWofost app to the SQL database

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -13,6 +13,9 @@ parcel ID. The API will return the simulated yield for the specified input.
 from fastapi import FastAPI
 
 from api.endpoints import endpoints
+from ukwofost.core import engine
 
 app = FastAPI()
 app.include_router(endpoints.router)
+
+_ = engine

--- a/ukwofost/core/__init__.py
+++ b/ukwofost/core/__init__.py
@@ -9,9 +9,11 @@ UkWofost package initialisation file
 import os
 
 from ukwofost.core.config_parser import ConfigReader
+from ukwofost.utility.db import create_db_connection
 from ukwofost.utility.paths import ROOT_DIR
 
 config_path = os.path.join(ROOT_DIR, "config.ini")
 # pylint: disable=E1101
 app_config = ConfigReader(config_path)
 # pylint: enable=E1101
+engine = create_db_connection(app_config)

--- a/ukwofost/core/parcel.py
+++ b/ukwofost/core/parcel.py
@@ -87,7 +87,7 @@ class Parcel:
     def _calc_elevation(os_code):
         """Retrieve elevation of the centroid of the parcel"""
         try:
-            dtm_data = get_dtm_values(os_code, app_config)["elevation"]
+            dtm_data = get_dtm_values(os_code)["elevation"]
         except Exception as e:
             print(f"Error retrieving elevation for OS code {os_code}: {e}")
             dtm_data = 0.0
@@ -100,7 +100,7 @@ class Parcel:
         Compute OS grid code of the centroid
         of the parcel with id = "parcel_id"
         """
-        parcels_shapefile = load_parcel_from_db(self.parcel_id, app_config)
+        parcels_shapefile = load_parcel_from_db(self.parcel_id)
         parcels_shapefile = parcels_shapefile.to_crs(epsg=4326)
         parcel_centroid = parcels_shapefile[
             parcels_shapefile["gid"] == str(self.parcel_id)

--- a/ukwofost/core/utils.py
+++ b/ukwofost/core/utils.py
@@ -104,7 +104,6 @@ import json
 import math
 import os
 import re
-import urllib
 from datetime import date, datetime, time, timedelta
 from math import acos, asin, cos
 from math import degrees as deg
@@ -117,7 +116,9 @@ import numpy as np
 import pandas as pd
 import psycopg2
 from pyproj import Transformer
-from sqlalchemy import create_engine
+from sqlalchemy import text
+
+from ukwofost.core import engine
 
 
 class BNGError(Exception):
@@ -749,7 +750,7 @@ def int_to_date(int_to_convert, reference=None):
     return date_obj
 
 
-def get_dtm_values(parcel_os_code, app_config):
+def get_dtm_values(parcel_os_code):
     """
     Query the DTM database based on longitude and latitude to retrieve
     elevation, slope and aspect data.
@@ -762,31 +763,9 @@ def get_dtm_values(parcel_os_code, app_config):
     # find the closest 50m grid cell in the DEM
     lon, lat = osgrid2lonlat(parcel_os_code)
     lon_min, lon_max, lat_min, lat_max = lon - 50, lon + 50, lat - 50, lat + 50
-    conn = None
     try:
-        db_name = os.path.expandvars(
-            app_config.db_parameters.get("db_name", "")
-        )
-        db_name = None if not db_name else db_name
-        db_user = os.path.expandvars(
-            app_config.db_parameters.get("username", "")
-        )
-        db_user = None if not db_user else db_user
-        db_password = os.path.expandvars(
-            app_config.db_parameters.get("password", "")
-        )
-        db_host = os.path.expandvars(app_config.db_parameters.get("host", ""))
-        db_password = None if not db_password else db_password
-        conn = psycopg2.connect(
-            user=db_user,
-            password=db_password,
-            database=db_name,
-            host=db_host,
-            port="5432",
-        )
-        conn.autocommit = True
-        cur = conn.cursor()
-        sql = f"""
+        sql = text(
+            """
             SELECT
                 terrain.x,
                 terrain.y,
@@ -794,11 +773,22 @@ def get_dtm_values(parcel_os_code, app_config):
                 terrain.slope,
                 terrain.aspect
             FROM dtm.dtm_slope_aspect AS terrain
-            WHERE terrain.x BETWEEN {lon_min} AND {lon_max}
-            AND terrain.y BETWEEN {lat_min} AND {lat_max};
+            WHERE terrain.x BETWEEN :lon_min AND :lon_max
+            AND terrain.y BETWEEN :lat_min AND :lat_max;
         """
-        cur.execute(sql)
-        sql_return = cur.fetchall()
+        )
+        with engine.connect() as connection:
+            sql_return = connection.execute(
+                sql,
+                {
+                    "lon_min": lon_min,
+                    "lon_max": lon_max,
+                    "lat_min": lat_min,
+                    "lat_max": lat_max,
+                },
+            ).fetchall()
+        if not sql_return:
+            return {"x": 0, "y": 0, "elevation": 0, "slope": 0, "aspect": 0}
         lon_lst = [x[0] for x in sql_return]
         lat_lst = [x[1] for x in sql_return]
         closest_lon, closest_lat = nearest(lon, lon_lst), nearest(lat, lat_lst)
@@ -812,21 +802,10 @@ def get_dtm_values(parcel_os_code, app_config):
         dtm_dict = dtm_dict = dict(zip(dict_keys, dtm_vals))
         return dtm_dict
 
-    except psycopg2.OperationalError as error:
-        print(
-            f"WARNING: Database connection failed: {error}"
-            f" - returning default values."
-        )
-        return {"x": 0, "y": 0, "elevation": 0, "slope": 0, "aspect": 0}
-
-    # pylint: disable=W0718
     except Exception as error:
         print(f"An unexpected error occurred: {error}")
         return {"x": 0, "y": 0, "elevation": 0, "slope": 0, "aspect": 0}
     # pylint: enable=W0718
-    finally:
-        if conn is not None:
-            conn.close()
 
 
 def find_contiguous_sets(data_frame, col_name):
@@ -1009,7 +988,7 @@ def estimate_angstrom(toa=None, toc=None):
     return angstrom_a, angstrom_b
 
 
-def load_parcel_from_db(parcel_gid, app_config):
+def load_parcel_from_db(parcel_gid):
     """
     Query a parcel database to retrieve parcel data
 
@@ -1024,28 +1003,7 @@ def load_parcel_from_db(parcel_gid, app_config):
     """
 
     # pylint: disable=W0718
-    conn = None
     try:
-        db_name = os.path.expandvars(
-            app_config.db_parameters.get("db_name", "")
-        )
-        db_name = None if not db_name else db_name
-        db_user = os.path.expandvars(
-            app_config.db_parameters.get("username", "")
-        )
-        db_user = None if not db_user else db_user
-        db_password = os.path.expandvars(
-            app_config.db_parameters.get("password", "")
-        )
-        db_host = os.path.expandvars(app_config.db_parameters.get("host", ""))
-        db_password = (
-            None if not db_password else urllib.parse.quote_plus(db_password)
-        )
-        conn = (
-            "postgresql+psycopg2://"
-            f"{db_user}:{db_password}@{db_host}:5432/{db_name}"
-        )
-        engine = create_engine(conn)
         sql = f"""
             SELECT * FROM parcels.parcels WHERE gid = '{parcel_gid}';
         """

--- a/ukwofost/utility/db.py
+++ b/ukwofost/utility/db.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2023 LEEP, University of Exeter (UK)
+# Mattia Mancini (m.c.mancini@exeter.ac.uk), September 2025
+# =========================================================
+"""
+db.py
+=====
+Database utility functions
+"""
+import os
+import urllib
+
+from sqlalchemy import create_engine
+
+
+def create_db_connection(app_config):
+    """Create a database connection using SQLAlchemy."""
+    db_name = os.path.expandvars(app_config.db_parameters.get("db_name", ""))
+    db_name = None if not db_name else db_name
+    db_user = os.path.expandvars(app_config.db_parameters.get("username", ""))
+    db_user = None if not db_user else db_user
+    db_password = os.path.expandvars(
+        app_config.db_parameters.get("password", "")
+    )
+    db_host = os.path.expandvars(app_config.db_parameters.get("host", ""))
+    db_password = (
+        None if not db_password else urllib.parse.quote_plus(db_password)
+    )
+
+    database_url = (
+        f"postgresql+psycopg2://{db_user}:{db_password}"
+        f"@{db_host}:5432/{db_name}"
+    )
+
+    engine = create_engine(
+        database_url,
+        pool_size=300,  # adjust depending on expected load
+        max_overflow=100,  # how many extra connections if pool is full
+        pool_timeout=30,  # wait time before giving up on a connection
+        pool_recycle=1800,  # refresh connections periodically
+    )
+    return engine


### PR DESCRIPTION
This PR attmepts to address Issue #108.
There is apparently a limit in the number of concurrent connections that can happen at the same time to a postgreSQL database. When trying to optimise management running instances of wofost in parallel, the whole thing crashes with the following error: `An unexpected error occurred: (psycopg2.OperationalError) connection to server at "localhost" (127.0.0.1), port 5432 failed: FATAL:  remaining connection slots are reserved for roles with the SUPERUSER attribute`.  

To fix this, I created an utility function that generates a SQLAlchemy engine with a pool_size=300 and max_overflow=100; this is created only once, either when initialising the Uvicorn UkWofost app or when importing anything from ukwofost.core for the first time. This global engine is then used any time a connection to the SQL database is needed. This is clunkier than adding the engine within the app; I had to do this just because the code should also allow to run UkWofost locally and algorithmically without having to start and run the uvicorn server. 