### PR TITLE
Redesigned database connections

### DIFF
--- a/api/core/simulation.py
+++ b/api/core/simulation.py
@@ -20,13 +20,12 @@ from ukwofost.core.simulation_manager import WofostSimulator
 
 
 def run_wofost_simulation(
-    run,
-    output_mode: Literal["harvest", "full", "summary"],
+    run, output_mode: Literal["harvest", "full", "summary"], db=None
 ):
     """Run an instance of a crop in WOFOST."""
     parcel = run.parcel_id
     try:
-        parcel_obj = Parcel(parcel)
+        parcel_obj = Parcel(parcel, db=db)
         sim = WofostSimulator(
             location=parcel_obj,
             weather_provider="Mesoclim",

--- a/api/endpoints/endpoints.py
+++ b/api/endpoints/endpoints.py
@@ -11,19 +11,23 @@ the WOFOST model.
 
 from typing import Literal
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
 
 from api.models.crop import BulkRunner, SingleCrop
+from api.services.dependencies import get_db
 from api.services.wofost_runner import run_from_payload, run_single_crop
 
 router = APIRouter()
 
 
 @router.post("/run_crop")
-def run_crop(request: SingleCrop):
+def run_crop(request: SingleCrop, db: Session = Depends(get_db)):
     """Run a WOFOST simulation for a crop in a specific year and parcel."""
     try:
-        result = run_single_crop(request.crop, request.year, request.parcel_id)
+        result = run_single_crop(
+            request.crop, request.year, request.parcel_id, db
+        )
         return {"result": result}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e)) from e
@@ -31,11 +35,13 @@ def run_crop(request: SingleCrop):
 
 @router.post("/run_bulk")
 async def run_bulk(
-    request: BulkRunner, summary: Literal["harvest", "full", "summary"]
+    request: BulkRunner,
+    summary: Literal["harvest", "full", "summary"],
+    db: Session = Depends(get_db),
 ):
     """Run bulk WOFOST simulations."""
     try:
-        result = run_from_payload(request.runs, summary=summary)
+        result = run_from_payload(request.runs, summary=summary, db=db)
         return {"result": result}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e)) from e

--- a/api/main.py
+++ b/api/main.py
@@ -13,9 +13,6 @@ parcel ID. The API will return the simulated yield for the specified input.
 from fastapi import FastAPI
 
 from api.endpoints import endpoints
-from ukwofost.core import engine
 
 app = FastAPI()
 app.include_router(endpoints.router)
-
-_ = engine

--- a/api/services/dependencies.py
+++ b/api/services/dependencies.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2023 LEEP, University of Exeter (UK)
+# Mattia Mancini (m.c.mancini@exeter.ac.uk), September 2025
+# =========================================================
+"""
+ddependencies.py
+================
+Database session generator
+"""
+
+from ukwofost.utility.db import SessionLocal
+
+
+def get_db():
+    """Dependency to get DB session."""
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/api/services/wofost_runner.py
+++ b/api/services/wofost_runner.py
@@ -20,16 +20,26 @@ from ukwofost.core.crop_manager import Crop
 from ukwofost.core.defaults import defaults
 from ukwofost.core.parcel import Parcel
 from ukwofost.core.simulation_manager import WofostSimulator
+from ukwofost.utility.db import SessionLocal
 
 logging.disable(logging.CRITICAL)
 
 
-def run_single_crop(crop: str, year: int, parcel_id: int):
+def _worker(run, summary):
+    """Worker with its own db session for parallel pooling."""
+    session = SessionLocal()
+    try:
+        return run_wofost_simulation(run, summary, db=session)
+    finally:
+        session.close()
+
+
+def run_single_crop(crop: str, year: int, parcel_id: int, db):
     """
     Run a WOFOST simulation for a specific crop and year
     at a given parcel with standard managment.
     """
-    parcel = Parcel(parcel_id)
+    parcel = Parcel(parcel_id, db=db)
     sim = WofostSimulator(
         location=parcel, weather_provider="Mesoclim", soil_provider="SoilGrids"
     )
@@ -46,6 +56,7 @@ def run_single_crop(crop: str, year: int, parcel_id: int):
 def run_from_payload(
     runs: List[Union[dict, BaseModel]],
     summary: Literal["harvest", "full", "summary"],
+    db=None,
     parallel: bool = True,
     max_workers: int = os.cpu_count() - 1,
 ) -> list:
@@ -63,14 +74,13 @@ def run_from_payload(
     """
 
     all_results = []
-
     # Attach an index to every run so we can trace it
     indexed_runs = [(f"run{i+1}", run) for i, run in enumerate(runs)]
 
     if parallel:
         with ProcessPoolExecutor(max_workers=max_workers) as executor:
             futures = {
-                executor.submit(run_wofost_simulation, run, summary): run_id
+                executor.submit(_worker, run, summary): run_id
                 for run_id, run in indexed_runs
             }
             for future in as_completed(futures):
@@ -81,7 +91,7 @@ def run_from_payload(
                     all_results.append(df_result)
     else:
         for run_id, run in indexed_runs:
-            df_result = run_wofost_simulation(run, summary)
+            df_result = run_wofost_simulation(run, summary, db=db)
             if not df_result.empty:
                 df_result["run_id"] = run_id
                 all_results.append(df_result)

--- a/ukwofost/core/__init__.py
+++ b/ukwofost/core/__init__.py
@@ -9,11 +9,9 @@ UkWofost package initialisation file
 import os
 
 from ukwofost.core.config_parser import ConfigReader
-from ukwofost.utility.db import create_db_connection
 from ukwofost.utility.paths import ROOT_DIR
 
 config_path = os.path.join(ROOT_DIR, "config.ini")
 # pylint: disable=E1101
 app_config = ConfigReader(config_path)
 # pylint: enable=E1101
-engine = create_db_connection(app_config)

--- a/ukwofost/core/parcel.py
+++ b/ukwofost/core/parcel.py
@@ -19,6 +19,7 @@ from ukwofost.core.utils import (
     load_parcel_from_db,
     lonlat2osgrid,
 )
+from ukwofost.utility.db import SessionLocal
 
 
 class Parcel:
@@ -48,8 +49,9 @@ class Parcel:
         app_config.data_dirs["parcel_dir"], "land_parcels.shp"
     )
 
-    def __init__(self, gid):
+    def __init__(self, gid, db=None):
         self._parcel_id = gid
+        self._db = db or SessionLocal()
 
     @property
     def parcel_id(self):
@@ -80,14 +82,14 @@ class Parcel:
     @property
     def elevation(self):
         """Set parcel elevation if exists"""
-        return self._calc_elevation(self.osgrid_code)
+        return self._calc_elevation(self.osgrid_code, self._db)
 
     # pylint: disable=W0718
     @staticmethod
-    def _calc_elevation(os_code):
+    def _calc_elevation(os_code, db):
         """Retrieve elevation of the centroid of the parcel"""
         try:
-            dtm_data = get_dtm_values(os_code)["elevation"]
+            dtm_data = get_dtm_values(os_code, db)["elevation"]
         except Exception as e:
             print(f"Error retrieving elevation for OS code {os_code}: {e}")
             dtm_data = 0.0
@@ -100,7 +102,7 @@ class Parcel:
         Compute OS grid code of the centroid
         of the parcel with id = "parcel_id"
         """
-        parcels_shapefile = load_parcel_from_db(self.parcel_id)
+        parcels_shapefile = load_parcel_from_db(self.parcel_id, self._db)
         parcels_shapefile = parcels_shapefile.to_crs(epsg=4326)
         parcel_centroid = parcels_shapefile[
             parcels_shapefile["gid"] == str(self.parcel_id)

--- a/ukwofost/core/utils.py
+++ b/ukwofost/core/utils.py
@@ -118,7 +118,7 @@ import psycopg2
 from pyproj import Transformer
 from sqlalchemy import text
 
-from ukwofost.core import engine
+from ukwofost.utility.db import SessionLocal
 
 
 class BNGError(Exception):
@@ -750,7 +750,7 @@ def int_to_date(int_to_convert, reference=None):
     return date_obj
 
 
-def get_dtm_values(parcel_os_code):
+def get_dtm_values(parcel_os_code, db=None):
     """
     Query the DTM database based on longitude and latitude to retrieve
     elevation, slope and aspect data.
@@ -763,6 +763,11 @@ def get_dtm_values(parcel_os_code):
     # find the closest 50m grid cell in the DEM
     lon, lat = osgrid2lonlat(parcel_os_code)
     lon_min, lon_max, lat_min, lat_max = lon - 50, lon + 50, lat - 50, lat + 50
+    if db is None:
+        db = SessionLocal()  # standalone usage
+        created_here = True
+    else:
+        created_here = False
     try:
         sql = text(
             """
@@ -777,16 +782,16 @@ def get_dtm_values(parcel_os_code):
             AND terrain.y BETWEEN :lat_min AND :lat_max;
         """
         )
-        with engine.connect() as connection:
-            sql_return = connection.execute(
-                sql,
-                {
-                    "lon_min": lon_min,
-                    "lon_max": lon_max,
-                    "lat_min": lat_min,
-                    "lat_max": lat_max,
-                },
-            ).fetchall()
+        conn = db.connection()
+        sql_return = conn.execute(
+            sql,
+            {
+                "lon_min": lon_min,
+                "lon_max": lon_max,
+                "lat_min": lat_min,
+                "lat_max": lat_max,
+            },
+        ).fetchall()
         if not sql_return:
             return {"x": 0, "y": 0, "elevation": 0, "slope": 0, "aspect": 0}
         lon_lst = [x[0] for x in sql_return]
@@ -805,6 +810,10 @@ def get_dtm_values(parcel_os_code):
     except Exception as error:
         print(f"An unexpected error occurred: {error}")
         return {"x": 0, "y": 0, "elevation": 0, "slope": 0, "aspect": 0}
+
+    finally:
+        if created_here:
+            db.close()
     # pylint: enable=W0718
 
 
@@ -988,7 +997,7 @@ def estimate_angstrom(toa=None, toc=None):
     return angstrom_a, angstrom_b
 
 
-def load_parcel_from_db(parcel_gid):
+def load_parcel_from_db(parcel_gid, db=None):
     """
     Query a parcel database to retrieve parcel data
 
@@ -1001,14 +1010,19 @@ def load_parcel_from_db(parcel_gid):
     ------
     :return: GeoDataFrame containing the parcel data
     """
-
     # pylint: disable=W0718
+    if db is None:
+        db = SessionLocal()  # standalone usage
+        created_here = True
+    else:
+        created_here = False
     try:
+
         sql = f"""
             SELECT * FROM parcels.parcels WHERE gid = '{parcel_gid}';
         """
-        with engine.connect() as connection:
-            sql_return = gpd.read_postgis(sql, connection, geom_col="geom")
+        conn = db.connection()
+        sql_return = gpd.read_postgis(sql, conn, geom_col="geom")
         # cur.execute(sql)
         # sql_return = cur.fetchall()
         # if len(sql_return) == 0:
@@ -1019,4 +1033,10 @@ def load_parcel_from_db(parcel_gid):
         print(f"WARNING: Database connection failed: {error}")
     except Exception as error:
         print(f"An unexpected error occurred: {error}")
+    finally:
+        if created_here:
+            db.close()
     # pylint: enable=W0718
+
+
+# pylint: enable=R1710

--- a/ukwofost/utility/db.py
+++ b/ukwofost/utility/db.py
@@ -11,6 +11,9 @@ import os
 import urllib
 
 from sqlalchemy import create_engine
+from sqlalchemy.orm import scoped_session, sessionmaker
+
+from ukwofost.core import app_config
 
 
 def create_db_connection(app_config):
@@ -40,3 +43,12 @@ def create_db_connection(app_config):
         pool_recycle=1800,  # refresh connections periodically
     )
     return engine
+
+
+SessionLocal = scoped_session(
+    sessionmaker(
+        autocommit=False,
+        autoflush=False,
+        bind=create_db_connection(app_config),
+    )
+)


### PR DESCRIPTION
This PR addresses Issue #112

**Problem**
Bulk simulations in the WOFOST API were opening a new database connection for every parcel in parallel runs. When many runs were submitted at once, this caused PostgreSQL connection exhaustion and `NoneType` / `to_crs` errors.  

**Solution**
- Introduced a centralized SQLAlchemy session factory (`SessionLoca`l) in `ukwofost.core.utility.db`.

- FastAPI endpoints now inject a scoped session via `Depends(get_db)` for sequential runs.

- Simulation functions (`Parcel`, `run_wofost_simulation`, `run_from_payload`) were refactored to accept a db session parameter.

- For parallel execution, each worker process creates its own session from `SessionLocal()`, preventing cross-process session sharing and pickling issues.

- Sequential execution reuses the injected session to minimize connection usage.