### PR TITLE
Updated default values for parameters which will ont be calibrated

### DIFF
--- a/ukwofost/core/defaults.py
+++ b/ukwofost/core/defaults.py
@@ -26,11 +26,12 @@ cropd = YAMLCropDataProvider(
 
 # SITE PARAMETERS
 sitedata = WOFOST80SiteDataProvider(
-    WAV=100,
+    WAV=0,
     CO2=360,
     NAVAILI=80,
     PAVAILI=10,
     KAVAILI=20,
+    SMLIM=0.6,
 )
 
 sitedata["TemperatureSoilinit"] = 5.0


### PR DESCRIPTION
With this PR we address Issue #117 by removing parameters which will not be calibrated. This has been done by setting default site data to have SMLIM not binding (SMLIM = 0.6)